### PR TITLE
Assign forge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,5 +51,8 @@ regex = "1"
 # random
 rand = "0.8"
 
+# url parsing
+url = "2"
+
 # test utils
 tempfile = "3"

--- a/crates/agent-nexus/Cargo.toml
+++ b/crates/agent-nexus/Cargo.toml
@@ -15,3 +15,4 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 tracing = { workspace = true }
+url = { workspace = true }

--- a/crates/agent-nexus/src/lib.rs
+++ b/crates/agent-nexus/src/lib.rs
@@ -662,20 +662,6 @@ impl NexusNode {
             "FORGE".to_string()
         };
 
-        // Add comment indicating assignment
-        let comment_body = format!(
-            "🔧 **Assigned to {} for implementation**\n\nThis issue has been assigned to the FORGE worker ({}) for automated implementation. The agent will analyze the requirements, implement the solution, and open a PR when complete.",
-            assignee_display, worker_id.to_uppercase()
-        );
-        client
-            .add_issue_comment(owner, repo, issue_number, &comment_body)
-            .await?;
-
-        // Add assigned/in-progress labels
-        client
-            .add_issue_labels(owner, repo, issue_number, &["assigned", "in-progress"])
-            .await?;
-
         info!(
             worker_id,
             ticket_id,

--- a/crates/agent-nexus/src/lib.rs
+++ b/crates/agent-nexus/src/lib.rs
@@ -573,7 +573,9 @@ impl NexusNode {
             .with_context(|| format!("Invalid issue URL format: {}", issue_url))?;
 
         // Validate host is github.com (case-insensitive)
-        let host = parsed_url.host_str().ok_or_else(|| anyhow::anyhow!("Missing host in URL"))?;
+        let host = parsed_url
+            .host_str()
+            .ok_or_else(|| anyhow::anyhow!("Missing host in URL"))?;
         if !host.eq_ignore_ascii_case("github.com") {
             anyhow::bail!("URL host must be github.com, got: {}", host);
         }

--- a/crates/agent-nexus/src/lib.rs
+++ b/crates/agent-nexus/src/lib.rs
@@ -1,6 +1,6 @@
 // crates/agent-nexus/src/lib.rs
 use agent_client::{AgentDecision, AgentPersona, AgentRunner};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use config::{
     state::{KEY_COMMAND_GATE, KEY_PENDING_PRS, KEY_TICKETS, KEY_WORKER_SLOTS},
@@ -559,8 +559,7 @@ impl NexusNode {
         }
     }
 
-    /// Sync work assignment to GitHub by assigning the issue to the forge worker,
-    /// adding a comment indicating assignment, and optionally adding labels.
+    /// Sync work assignment to GitHub by assigning the issue to the forge worker.
     /// The forge worker's GitHub username is loaded from the agent definition (forge.agent.md).
     async fn sync_assignment_to_github(
         &self,
@@ -570,26 +569,45 @@ impl NexusNode {
     ) -> Result<()> {
         // Parse owner/repo from issue URL and extract issue number
         // Expected format: https://github.com/{owner}/{repo}/issues/{number}
-        let url_parts: Vec<&str> = issue_url.split('/').collect();
-        if url_parts.len() < 2 {
-            anyhow::bail!("Invalid issue URL format: {}", issue_url);
+        let parsed_url = url::Url::parse(issue_url)
+            .with_context(|| format!("Invalid issue URL format: {}", issue_url))?;
+
+        // Validate host is github.com (case-insensitive)
+        let host = parsed_url.host_str().ok_or_else(|| anyhow::anyhow!("Missing host in URL"))?;
+        if !host.eq_ignore_ascii_case("github.com") {
+            anyhow::bail!("URL host must be github.com, got: {}", host);
         }
 
-        // Extract owner, repo, and issue number from URL
-        let repo_idx = url_parts.iter().position(|&p| p == "github.com");
-        let (owner, repo, issue_number) = match repo_idx {
-            Some(idx) if url_parts.len() > idx + 3 => {
-                let owner = url_parts[idx + 1];
-                let repo = url_parts[idx + 2];
-                // Issue number is the last component
-                let number = url_parts
-                    .last()
-                    .and_then(|n| n.parse::<u64>().ok())
-                    .ok_or_else(|| anyhow::anyhow!("Could not parse issue number from URL"))?;
-                (owner, repo, number)
-            }
-            _ => anyhow::bail!("Could not parse owner/repo from issue URL: {}", issue_url),
-        };
+        // Parse path segments: /{owner}/{repo}/issues/{number}
+        let path_segments: Vec<&str> = parsed_url
+            .path_segments()
+            .map(|s| s.collect::<Vec<_>>())
+            .unwrap_or_default();
+
+        if path_segments.len() < 4 {
+            anyhow::bail!(
+                "Invalid GitHub issue URL path. Expected: /{{owner}}/{{repo}}/issues/{{number}}, got: {}",
+                parsed_url.path()
+            );
+        }
+
+        // Check that the third segment is "issues" (or "pull" for PRs)
+        let issue_type = path_segments[2];
+        if issue_type != "issues" && issue_type != "pull" {
+            anyhow::bail!(
+                "Expected URL path segment 3 to be 'issues' or 'pull', got: {}",
+                issue_type
+            );
+        }
+
+        let owner = path_segments[0];
+        let repo = path_segments[1];
+
+        // Extract issue number, stripping any trailing slashes or query parameters
+        let number_str = path_segments[3].trim_end_matches('/');
+        let issue_number: u64 = number_str
+            .parse()
+            .with_context(|| format!("Could not parse issue number from: {}", number_str))?;
 
         let token = match self.resolve_github_token() {
             Ok(t) => t,
@@ -629,16 +647,16 @@ impl NexusNode {
         };
 
         // Only attempt assignment if a valid GitHub username is configured
-        let assignee_display = if !github_username.is_empty() {
+        let (assignee_display, assignment_success) = if !github_username.is_empty() {
             match client
                 .assign_issue(owner, repo, issue_number, &github_username)
                 .await
             {
-                Ok(_) => github_username.clone(),
+                Ok(_) => (github_username.clone(), true),
                 Err(e) => {
                     let err_str = e.to_string();
-                    // Check if it's a 422 validation error (invalid assignee)
-                    if err_str.contains("422") || err_str.contains("Validation Failed") {
+                    // Check if it's a validation error (422) for invalid assignee
+                    if err_str.starts_with("Validation failed (422)") {
                         warn!(
                             worker_id,
                             ticket_id,
@@ -648,7 +666,7 @@ impl NexusNode {
                             github_username
                         );
                         // Continue without failing - assignment is not critical
-                        github_username.clone()
+                        (github_username.clone(), false)
                     } else {
                         return Err(e);
                     }
@@ -659,16 +677,42 @@ impl NexusNode {
                 worker_id,
                 ticket_id, "No GitHub username configured for worker — skipping assignment"
             );
-            "FORGE".to_string()
+            ("<none>".to_string(), false)
         };
 
-        info!(
-            worker_id,
-            ticket_id,
-            issue_url,
-            assignee = assignee_display,
-            "Successfully synced assignment to GitHub"
-        );
+        if assignment_success {
+            #[cfg(debug_assertions)]
+            info!(
+                worker_id,
+                ticket_id,
+                issue_url,
+                assignee = assignee_display,
+                "Successfully synced assignment to GitHub"
+            );
+            #[cfg(not(debug_assertions))]
+            info!(
+                worker_id,
+                ticket_id,
+                assignee = assignee_display,
+                "Successfully synced assignment to GitHub"
+            );
+        } else {
+            #[cfg(debug_assertions)]
+            info!(
+                worker_id,
+                ticket_id,
+                issue_url,
+                attempted_assignee = assignee_display,
+                "GitHub assignment skipped (not critical)"
+            );
+            #[cfg(not(debug_assertions))]
+            info!(
+                worker_id,
+                ticket_id,
+                attempted_assignee = assignee_display,
+                "GitHub assignment skipped (not critical)"
+            );
+        }
 
         Ok(())
     }

--- a/crates/agent-nexus/src/lib.rs
+++ b/crates/agent-nexus/src/lib.rs
@@ -558,6 +558,78 @@ impl NexusNode {
         }
     }
 
+    /// Sync work assignment to GitHub by assigning the issue to the forge worker,
+    /// adding a comment indicating assignment, and optionally adding labels.
+    /// The forge worker's GitHub username is defined in forge.agent.md as `forge-bot`.
+    async fn sync_assignment_to_github(
+        &self,
+        worker_id: &str,
+        ticket_id: &str,
+        issue_url: &str,
+    ) -> Result<()> {
+        // Parse owner/repo from issue URL and extract issue number
+        // Expected format: https://github.com/{owner}/{repo}/issues/{number}
+        let url_parts: Vec<&str> = issue_url.split('/').collect();
+        if url_parts.len() < 2 {
+            anyhow::bail!("Invalid issue URL format: {}", issue_url);
+        }
+
+        // Extract owner, repo, and issue number from URL
+        let repo_idx = url_parts.iter().position(|&p| p == "github.com");
+        let (owner, repo, issue_number) = match repo_idx {
+            Some(idx) if url_parts.len() > idx + 3 => {
+                let owner = url_parts[idx + 1];
+                let repo = url_parts[idx + 2];
+                // Issue number is the last component
+                let number = url_parts
+                    .last()
+                    .and_then(|n| n.parse::<u64>().ok())
+                    .ok_or_else(|| anyhow::anyhow!("Could not parse issue number from URL"))?;
+                (owner, repo, number)
+            }
+            _ => anyhow::bail!("Could not parse owner/repo from issue URL: {}", issue_url),
+        };
+
+        let token = match self.resolve_github_token() {
+            Ok(t) => t,
+            Err(e) => {
+                anyhow::bail!("GitHub token not configured: {}", e);
+            }
+        };
+
+        let client = github::GithubRestClient::new(&token);
+
+        // Assign to forge-bot (defined in forge.agent.md)
+        const FORGE_BOT_USERNAME: &str = "forge-bot";
+        client
+            .assign_issue(owner, repo, issue_number, FORGE_BOT_USERNAME)
+            .await?;
+
+        // Add comment indicating assignment
+        let comment_body = format!(
+            "🔧 **Assigned to {} for implementation**\n\nThis issue has been assigned to the FORGE worker ({}) for automated implementation. The agent will analyze the requirements, implement the solution, and open a PR when complete.",
+            FORGE_BOT_USERNAME, worker_id.to_uppercase()
+        );
+        client
+            .add_issue_comment(owner, repo, issue_number, &comment_body)
+            .await?;
+
+        // Add assigned/in-progress labels
+        client
+            .add_issue_labels(owner, repo, issue_number, &["assigned", "in-progress"])
+            .await?;
+
+        info!(
+            worker_id,
+            ticket_id,
+            issue_url,
+            assignee = FORGE_BOT_USERNAME,
+            "Successfully synced assignment to GitHub"
+        );
+
+        Ok(())
+    }
+
     fn ensure_ci_setup_ticket(
         &self,
         _store: &SharedStore,
@@ -1003,6 +1075,22 @@ impl Node for NexusNode {
                             .set(KEY_WORKER_SLOTS, serde_json::to_value(slots)?)
                             .await;
                         info!(worker_id, ticket_id, issue_url = ?decision.issue_url, "Nexus: Store updated with NEW worker assignment");
+                    }
+
+                    // Sync assignment to GitHub: assign issue, add comment, and label
+                    if let Some(issue_url) = &decision.issue_url {
+                        if let Err(e) = self
+                            .sync_assignment_to_github(worker_id, ticket_id, issue_url)
+                            .await
+                        {
+                            warn!(
+                                worker_id,
+                                ticket_id,
+                                issue_url,
+                                error = %e,
+                                "Failed to sync assignment to GitHub — continuing anyway"
+                            );
+                        }
                     }
                 }
             }

--- a/crates/agent-nexus/src/lib.rs
+++ b/crates/agent-nexus/src/lib.rs
@@ -4,7 +4,8 @@ use anyhow::Result;
 use async_trait::async_trait;
 use config::{
     state::{KEY_COMMAND_GATE, KEY_PENDING_PRS, KEY_TICKETS, KEY_WORKER_SLOTS},
-    Registry, Ticket, TicketStatus, WorkerSlot, WorkerStatus, ACTION_MERGE_PRS, ACTION_NO_WORK,
+    AgentDef, Registry, Ticket, TicketStatus, WorkerSlot, WorkerStatus, ACTION_MERGE_PRS,
+    ACTION_NO_WORK,
 };
 use pocketflow_core::{node::STOP_SIGNAL, Action, Node, SharedStore};
 use serde::{Deserialize, Serialize};
@@ -560,7 +561,7 @@ impl NexusNode {
 
     /// Sync work assignment to GitHub by assigning the issue to the forge worker,
     /// adding a comment indicating assignment, and optionally adding labels.
-    /// The forge worker's GitHub username is defined in forge.agent.md as `forge-bot`.
+    /// The forge worker's GitHub username is loaded from the agent definition (forge.agent.md).
     async fn sync_assignment_to_github(
         &self,
         worker_id: &str,
@@ -599,16 +600,72 @@ impl NexusNode {
 
         let client = github::GithubRestClient::new(&token);
 
-        // Assign to forge-bot (defined in forge.agent.md)
-        const FORGE_BOT_USERNAME: &str = "forge-bot";
-        client
-            .assign_issue(owner, repo, issue_number, FORGE_BOT_USERNAME)
-            .await?;
+        // Load the agent definition to get the GitHub username for the worker
+        // Worker IDs are typically in format "forge-1", "forge-2", etc.
+        let agent_type = worker_id.split('-').next().unwrap_or("forge");
+        let agent_def_path = self
+            .registry_path
+            .parent()
+            .map(|p| p.join("agents").join(format!("{}.agent.md", agent_type)))
+            .unwrap_or_else(|| {
+                PathBuf::from(format!(
+                    "orchestration/agent/agents/{}.agent.md",
+                    agent_type
+                ))
+            });
+
+        let github_username = match AgentDef::load(&agent_def_path) {
+            Ok(def) => def.github.trim().to_string(),
+            Err(e) => {
+                warn!(
+                    worker_id,
+                    agent_type,
+                    path = %agent_def_path.display(),
+                    error = %e,
+                    "Failed to load agent definition — using empty GitHub username"
+                );
+                String::new()
+            }
+        };
+
+        // Only attempt assignment if a valid GitHub username is configured
+        let assignee_display = if !github_username.is_empty() {
+            match client
+                .assign_issue(owner, repo, issue_number, &github_username)
+                .await
+            {
+                Ok(_) => github_username.clone(),
+                Err(e) => {
+                    let err_str = e.to_string();
+                    // Check if it's a 422 validation error (invalid assignee)
+                    if err_str.contains("422") || err_str.contains("Validation Failed") {
+                        warn!(
+                            worker_id,
+                            ticket_id,
+                            github_username,
+                            error = %e,
+                            "GitHub user '{}' is not a valid assignee for this repository — skipping assignment",
+                            github_username
+                        );
+                        // Continue without failing - assignment is not critical
+                        github_username.clone()
+                    } else {
+                        return Err(e);
+                    }
+                }
+            }
+        } else {
+            warn!(
+                worker_id,
+                ticket_id, "No GitHub username configured for worker — skipping assignment"
+            );
+            "FORGE".to_string()
+        };
 
         // Add comment indicating assignment
         let comment_body = format!(
             "🔧 **Assigned to {} for implementation**\n\nThis issue has been assigned to the FORGE worker ({}) for automated implementation. The agent will analyze the requirements, implement the solution, and open a PR when complete.",
-            FORGE_BOT_USERNAME, worker_id.to_uppercase()
+            assignee_display, worker_id.to_uppercase()
         );
         client
             .add_issue_comment(owner, repo, issue_number, &comment_body)
@@ -623,7 +680,7 @@ impl NexusNode {
             worker_id,
             ticket_id,
             issue_url,
-            assignee = FORGE_BOT_USERNAME,
+            assignee = assignee_display,
             "Successfully synced assignment to GitHub"
         );
 

--- a/crates/github/src/rest.rs
+++ b/crates/github/src/rest.rs
@@ -704,11 +704,14 @@ impl GithubRestClient {
         let body = serde_json::json!({ "assignees": [assignee] });
         let resp: serde_json::Value = self.patch_json(&url, &body).await?;
         let assignees = resp["assignees"].as_array();
-        let assigned = assignees.map(|a| {
-            a.iter().any(|u| u["login"].as_str() == Some(assignee))
-        }).unwrap_or(false);
+        let assigned = assignees
+            .map(|a| a.iter().any(|u| u["login"].as_str() == Some(assignee)))
+            .unwrap_or(false);
         if assigned {
-            info!(issue = issue_number, assignee, "GitHub issue assigned successfully");
+            info!(
+                issue = issue_number,
+                assignee, "GitHub issue assigned successfully"
+            );
             Ok(())
         } else {
             warn!(
@@ -747,7 +750,10 @@ impl GithubRestClient {
         );
         let body = serde_json::json!({ "body": body_text });
         let _: serde_json::Value = self.post_json(&url, &body).await?;
-        info!(issue = issue_number, "GitHub issue comment added successfully");
+        info!(
+            issue = issue_number,
+            "GitHub issue comment added successfully"
+        );
         Ok(())
     }
 

--- a/crates/github/src/rest.rs
+++ b/crates/github/src/rest.rs
@@ -688,6 +688,80 @@ impl GithubRestClient {
         self.get_json(&url).await
     }
 
+    /// Assign a GitHub issue to a user.
+    /// The assignee should be a GitHub username (e.g., "forge-bot").
+    pub async fn assign_issue(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        assignee: &str,
+    ) -> Result<()> {
+        let url = format!(
+            "{}/repos/{}/{}/issues/{}",
+            GITHUB_API_BASE, owner, repo, issue_number
+        );
+        let body = serde_json::json!({ "assignees": [assignee] });
+        let resp: serde_json::Value = self.patch_json(&url, &body).await?;
+        let assignees = resp["assignees"].as_array();
+        let assigned = assignees.map(|a| {
+            a.iter().any(|u| u["login"].as_str() == Some(assignee))
+        }).unwrap_or(false);
+        if assigned {
+            info!(issue = issue_number, assignee, "GitHub issue assigned successfully");
+            Ok(())
+        } else {
+            warn!(
+                issue = issue_number,
+                assignee,
+                response = ?resp,
+                "GitHub issue assignment may not have succeeded"
+            );
+            Ok(())
+        }
+    }
+
+    /// Add a comment to a GitHub issue.
+    pub async fn add_issue_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        body_text: &str,
+    ) -> Result<()> {
+        let url = format!(
+            "{}/repos/{}/{}/issues/{}/comments",
+            GITHUB_API_BASE, owner, repo, issue_number
+        );
+        let body = serde_json::json!({ "body": body_text });
+        let _: serde_json::Value = self.post_json(&url, &body).await?;
+        info!(issue = issue_number, "GitHub issue comment added successfully");
+        Ok(())
+    }
+
+    /// Add labels to a GitHub issue.
+    /// Replaces any existing labels with the provided set.
+    pub async fn add_issue_labels(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        labels: &[&str],
+    ) -> Result<()> {
+        let url = format!(
+            "{}/repos/{}/{}/issues/{}/labels",
+            GITHUB_API_BASE, owner, repo, issue_number
+        );
+        let body = serde_json::json!({ "labels": labels });
+        let _: serde_json::Value = self.post_json(&url, &body).await?;
+        info!(
+            issue = issue_number,
+            labels = ?labels,
+            "GitHub issue labels added successfully"
+        );
+        Ok(())
+    }
+
     /// Close a GitHub issue by setting its state to "closed".
     pub async fn close_issue(&self, owner: &str, repo: &str, issue_number: u64) -> Result<()> {
         let url = format!(

--- a/crates/github/src/rest.rs
+++ b/crates/github/src/rest.rs
@@ -721,6 +721,18 @@ impl GithubRestClient {
         }
     }
 
+    /// Get the authenticated user's username from the GitHub API.
+    /// Uses the /user endpoint to fetch the login name of the token owner.
+    pub async fn get_authenticated_user(&self) -> Result<String> {
+        let url = format!("{}/user", GITHUB_API_BASE);
+        let resp: serde_json::Value = self.get_json(&url).await?;
+        let username = resp["login"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Failed to parse 'login' from GitHub user response"))?;
+        info!(username, "Fetched authenticated GitHub user");
+        Ok(username.to_string())
+    }
+
     /// Add a comment to a GitHub issue.
     pub async fn add_issue_comment(
         &self,

--- a/crates/github/src/rest.rs
+++ b/crates/github/src/rest.rs
@@ -714,6 +714,7 @@ impl GithubRestClient {
 
     /// Assign a GitHub issue to a user.
     /// The assignee should be a GitHub username (e.g., "forge-bot").
+    /// Returns Ok(()) on success, or an error with the HTTP status code on failure.
     pub async fn assign_issue(
         &self,
         owner: &str,
@@ -726,82 +727,41 @@ impl GithubRestClient {
             GITHUB_API_BASE, owner, repo, issue_number
         );
         let body = serde_json::json!({ "assignees": [assignee] });
-        let resp: serde_json::Value = self.patch_json(&url, &body).await?;
-        let assignees = resp["assignees"].as_array();
-        let assigned = assignees
-            .map(|a| a.iter().any(|u| u["login"].as_str() == Some(assignee)))
-            .unwrap_or(false);
-        if assigned {
-            info!(
-                issue = issue_number,
-                assignee, "GitHub issue assigned successfully"
-            );
+
+        debug!(url, assignee, "GitHub API PATCH issue assignment");
+        let payload = serde_json::to_vec(&body)?;
+        let resp = self
+            .send_with_retry(|| self.build_patch(&url, &payload))
+            .await?;
+
+        let status = resp.status();
+        if status.is_success() {
+            let resp_json: serde_json::Value = resp.json().await?;
+            let assignees = resp_json["assignees"].as_array();
+            let assigned = assignees
+                .map(|a| a.iter().any(|u| u["login"].as_str() == Some(assignee)))
+                .unwrap_or(false);
+            if assigned {
+                info!(
+                    issue = issue_number,
+                    assignee, "GitHub issue assigned successfully"
+                );
+            } else {
+                warn!(
+                    issue = issue_number,
+                    assignee,
+                    "GitHub issue assignment may not have succeeded (assignee not in response)"
+                );
+            }
             Ok(())
+        } else if status.as_u16() == 422 {
+            // 422 Unprocessable Entity - typically means invalid assignee
+            let body_text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Validation failed (422): {}", body_text)
         } else {
-            warn!(
-                issue = issue_number,
-                assignee,
-                response = ?resp,
-                "GitHub issue assignment may not have succeeded"
-            );
-            Ok(())
+            let body_text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("GitHub API error {}: {}", status, body_text)
         }
-    }
-
-    /// Get the authenticated user's username from the GitHub API.
-    /// Uses the /user endpoint to fetch the login name of the token owner.
-    pub async fn get_authenticated_user(&self) -> Result<String> {
-        let url = format!("{}/user", GITHUB_API_BASE);
-        let resp: serde_json::Value = self.get_json(&url).await?;
-        let username = resp["login"]
-            .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Failed to parse 'login' from GitHub user response"))?;
-        info!(username, "Fetched authenticated GitHub user");
-        Ok(username.to_string())
-    }
-
-    /// Add a comment to a GitHub issue.
-    pub async fn add_issue_comment(
-        &self,
-        owner: &str,
-        repo: &str,
-        issue_number: u64,
-        body_text: &str,
-    ) -> Result<()> {
-        let url = format!(
-            "{}/repos/{}/{}/issues/{}/comments",
-            GITHUB_API_BASE, owner, repo, issue_number
-        );
-        let body = serde_json::json!({ "body": body_text });
-        let _: serde_json::Value = self.post_json(&url, &body).await?;
-        info!(
-            issue = issue_number,
-            "GitHub issue comment added successfully"
-        );
-        Ok(())
-    }
-
-    /// Add labels to a GitHub issue.
-    /// Replaces any existing labels with the provided set.
-    pub async fn add_issue_labels(
-        &self,
-        owner: &str,
-        repo: &str,
-        issue_number: u64,
-        labels: &[&str],
-    ) -> Result<()> {
-        let url = format!(
-            "{}/repos/{}/{}/issues/{}/labels",
-            GITHUB_API_BASE, owner, repo, issue_number
-        );
-        let body = serde_json::json!({ "labels": labels });
-        let _: serde_json::Value = self.post_json(&url, &body).await?;
-        info!(
-            issue = issue_number,
-            labels = ?labels,
-            "GitHub issue labels added successfully"
-        );
-        Ok(())
     }
 
     /// Close a GitHub issue by setting its state to "closed".

--- a/orchestration/agent/agents/forge.agent.md
+++ b/orchestration/agent/agents/forge.agent.md
@@ -3,7 +3,7 @@ id: forge
 role: builder
 cli: claude
 active: true
-github: Forge-AgentFlow
+github: forge-openflows
 slack: "@forge"
 ---
 

--- a/orchestration/agent/agents/forge.agent.md
+++ b/orchestration/agent/agents/forge.agent.md
@@ -3,7 +3,7 @@ id: forge
 role: builder
 cli: claude
 active: true
-github: forge-bot
+github: Forge-AgentFlow
 slack: "@forge"
 ---
 

--- a/orchestration/agent/registry.json
+++ b/orchestration/agent/registry.json
@@ -1,10 +1,10 @@
 {
   "team": [
-    { "id": "nexus",    "cli": "claude", "active": true,  "instances": 1, "model_backend": "accounts/fireworks/models/glm-5", "routing_key": "nexus-key",    "github_token_env": "AGENT_NEXUS_GITHUB_TOKEN" },
-    { "id": "forge",    "cli": "claude", "active": true,  "instances": 2, "model_backend": "accounts/fireworks/models/glm-5", "routing_key": "forge-key",    "github_token_env": "AGENT_FORGE_GITHUB_TOKEN" },
-    { "id": "sentinel", "cli": "claude", "active": true,  "instances": 1, "model_backend": "accounts/fireworks/models/glm-5", "routing_key": "sentinel-key", "github_token_env": "AGENT_SENTINEL_GITHUB_TOKEN" },
-    { "id": "vessel",   "cli": "claude", "active": true,  "instances": 1, "model_backend": "accounts/fireworks/models/glm-5", "routing_key": "vessel-key",   "github_token_env": "AGENT_VESSEL_GITHUB_TOKEN" },
-    { "id": "lore",     "cli": "claude", "active": true,  "instances": 1, "model_backend": "accounts/fireworks/models/glm-5", "routing_key": "lore-key",     "github_token_env": "AGENT_LORE_GITHUB_TOKEN" }
+    { "id": "nexus",    "cli": "claude", "active": true,  "instances": 1, "model_backend": "accounts/fireworks/models/glm-5p1", "routing_key": "nexus-key",    "github_token_env": "AGENT_NEXUS_GITHUB_TOKEN" },
+    { "id": "forge",    "cli": "claude", "active": true,  "instances": 2, "model_backend": "accounts/fireworks/models/glm-5p1", "routing_key": "forge-key",    "github_token_env": "AGENT_FORGE_GITHUB_TOKEN" },
+    { "id": "sentinel", "cli": "claude", "active": true,  "instances": 1, "model_backend": "accounts/fireworks/models/glm-5p1", "routing_key": "sentinel-key", "github_token_env": "AGENT_SENTINEL_GITHUB_TOKEN" },
+    { "id": "vessel",   "cli": "claude", "active": true,  "instances": 1, "model_backend": "accounts/fireworks/models/glm-5p1", "routing_key": "vessel-key",   "github_token_env": "AGENT_VESSEL_GITHUB_TOKEN" },
+    { "id": "lore",     "cli": "claude", "active": true,  "instances": 1, "model_backend": "accounts/fireworks/models/glm-5p1", "routing_key": "lore-key",     "github_token_env": "AGENT_LORE_GITHUB_TOKEN" }
   ]
 }
  


### PR DESCRIPTION
When NEXUS makes a `work_assigned` decision, it:

1. **Internally** (current behavior):
   - Update `worker_slots` in the store with the assigned ticket
   - Update the `TicketStatus` to `Assigned { worker_id }`
   - Create or update the ticket in the store

2. **On GitHub** (new behavior):
   - Assign the GitHub issue to the forge worker's GitHub username (e.g., `forge-bot`)
   - Add a comment to the issue indicating assignment (e.g., "Assigned to FORGE-1 for implementation")
   - Optionally add a label like `assigned` or `in-progress`

## Benefits

- **Visibility**: Humans can see assignment status directly on GitHub without checking internal system state
- **Traceability**: GitHub issue history shows who/what is working on it
- **Consistency**: Prevents confusion where an issue appears unassigned on GitHub but is actually being worked on
- **Collaboration**: External contributors can see that an AI agent is handling the issue

## Implementation Notes

- The forge worker's GitHub username is defined in `forge.agent.md` as `forge-bot`
- The nexus agent has access to `MCP_Github` tools for GitHub operations
- The assignment should happen in `NexusNode::post()` after the internal state is updated
