### PR TITLE
fix: use cargo-zigbuild with glibc 2.17 for gnu release targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,21 +89,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            zigbuild_target: x86_64-unknown-linux-gnu.2.17
             archive_ext: tar.gz
+            use_zigbuild: true
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             archive_ext: tar.gz
-          - os: ubuntu-22.04
+            use_zigbuild: false
+          - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
+            zigbuild_target: aarch64-unknown-linux-gnu.2.17
             archive_ext: tar.gz
+            use_zigbuild: true
           - os: macos-latest
             target: x86_64-apple-darwin
             archive_ext: tar.gz
+            use_zigbuild: false
           - os: macos-latest
             target: aarch64-apple-darwin
             archive_ext: tar.gz
+            use_zigbuild: false
     steps:
       - uses: actions/checkout@v4
 
@@ -124,10 +131,14 @@ jobs:
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc' >> "$GITHUB_ENV"
 
+      - name: Install cargo-zigbuild
+        if: matrix.use_zigbuild
+        run: pip3 install cargo-zigbuild ziglang
+
       - name: Build binaries
         run: >
-          cargo build --release
-          --target ${{ matrix.target }}
+          ${{ matrix.use_zigbuild && 'cargo zigbuild' || 'cargo build' }} --release
+          --target ${{ matrix.use_zigbuild && matrix.zigbuild_target || matrix.target }}
           --bin openflows
           --bin openflows-setup
           --bin openflows-dashboard


### PR DESCRIPTION
## Problem

The previous fix used `ubuntu-22.04` runners for gnu builds to get glibc 2.35, but GitHub has upgraded `ubuntu-22.04` to glibc 2.39 — same as `ubuntu-latest`. This causes the build to fail with:

```
GLIBC_2.39 not found
```

on the build script runner, and the resulting binaries require glibc 2.39, breaking compatibility with older Linux systems.

## Fix

Switch gnu targets to use `cargo-zigbuild` targeting glibc 2.17. This ensures the produced binaries work on CentOS 7, Ubuntu 14.04+, Debian 8+, and virtually all Linux systems from the last decade.

### Key detail
The tarball step uses `target/${{ matrix.target }}/release/` (e.g. `target/x86_64-unknown-linux-gnu/release/`) **not** the zigbuild target with the `.2.17` suffix. This is because `cargo zigbuild --target x86_64-unknown-linux-gnu.2.17` outputs to the base triple directory.

### Matrix
| Target | Runner | Build method |
|--------|--------|-------------|
| `x86_64-unknown-linux-gnu` | ubuntu-latest | cargo-zigbuild (glibc 2.17) |
| `x86_64-unknown-linux-musl` | ubuntu-latest | cargo build |
| `aarch64-unknown-linux-gnu` | ubuntu-latest | cargo-zigbuild (glibc 2.17) |
| macOS targets | macos-latest | cargo build |

Supersedes the ubuntu-22.04 approach from #117.