### PR TITLE
fix: vessel node now uses resolver registry and searches OPENFLOWS_HO…

### DIFF
--- a/binary/src/bin/agentflow.rs
+++ b/binary/src/bin/agentflow.rs
@@ -1,7 +1,7 @@
 use agent_forge::ForgePairNode;
 use agent_lore::LoreNode;
 use agent_nexus::NexusNode;
-use agent_vessel::VesselNode;
+use agent_vessel::{VesselConfig, VesselNode};
 use anyhow::Result;
 use config::{
     ACTION_CI_FIX_NEEDED, ACTION_CONFLICTS_DETECTED, ACTION_DEPLOYED, ACTION_DEPLOY_FAILED,
@@ -184,7 +184,12 @@ async fn main() -> Result<()> {
         &workspace_dir,
         registry_path.clone(),
     ));
-    let vessel = Arc::new(VesselNode::from_env());
+    let vessel = Arc::new(VesselNode::new(
+        VesselConfig::from_registry(&registry_path).unwrap_or_else(|e| {
+            warn!(error = %e, "Failed to load vessel config from registry, using fallback");
+            VesselConfig::from_env()
+        }),
+    ));
     let lore = if registry.get("lore").is_some() {
         let lore_persona = resolver.persona_path("lore.agent.md");
         match LoreNode::new_with_registry(&workspace_dir, lore_persona, registry_path.clone()) {

--- a/crates/agent-vessel/src/node.rs
+++ b/crates/agent-vessel/src/node.rs
@@ -65,14 +65,37 @@ impl VesselNode {
     }
 
     pub fn from_env() -> Self {
-        let registry_path = std::env::current_dir()
+        // Search for registry in OPENFLOWS_HOME first, then workspace root, then CWD
+        let openflows_home = std::env::var("OPENFLOWS_HOME")
+            .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
+            .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
+            .unwrap_or_else(|_| ".openflows".to_string());
+        let oh_path = std::path::PathBuf::from(&openflows_home)
+            .join("orchestration")
+            .join("agent")
+            .join("registry.json");
+        let workspace_root = std::env::var("AGENTFLOW_WORKSPACE_ROOT")
+            .map(std::path::PathBuf::from)
+            .ok();
+        let ws_path = workspace_root.as_ref().map(|p| {
+            p.join("orchestration").join("agent").join("registry.json")
+        });
+        let cwd_path = std::env::current_dir()
             .ok()
             .map(|p| p.join("orchestration").join("agent").join("registry.json"));
 
+        let registry_path = if oh_path.exists() {
+            Some(oh_path)
+        } else if let Some(ref p) = ws_path {
+            if p.exists() { Some(p.clone()) } else { cwd_path }
+        } else {
+            cwd_path
+        };
+
         let config = match registry_path {
-            Some(path) if path.exists() => {
+            Some(ref path) if path.exists() => {
                 info!(registry_path = %path.display(), "VESSEL loading config from registry");
-                VesselConfig::from_registry(&path).unwrap_or_else(|e| {
+                VesselConfig::from_registry(path).unwrap_or_else(|e| {
                     warn!(error = %e, "VESSEL failed to load from registry, falling back to GITHUB_PERSONAL_ACCESS_TOKEN");
                     VesselConfig::from_env()
                 })

--- a/crates/agent-vessel/src/node.rs
+++ b/crates/agent-vessel/src/node.rs
@@ -77,9 +77,9 @@ impl VesselNode {
         let workspace_root = std::env::var("AGENTFLOW_WORKSPACE_ROOT")
             .map(std::path::PathBuf::from)
             .ok();
-        let ws_path = workspace_root.as_ref().map(|p| {
-            p.join("orchestration").join("agent").join("registry.json")
-        });
+        let ws_path = workspace_root
+            .as_ref()
+            .map(|p| p.join("orchestration").join("agent").join("registry.json"));
         let cwd_path = std::env::current_dir()
             .ok()
             .map(|p| p.join("orchestration").join("agent").join("registry.json"));
@@ -87,7 +87,11 @@ impl VesselNode {
         let registry_path = if oh_path.exists() {
             Some(oh_path)
         } else if let Some(ref p) = ws_path {
-            if p.exists() { Some(p.clone()) } else { cwd_path }
+            if p.exists() {
+                Some(p.clone())
+            } else {
+                cwd_path
+            }
         } else {
             cwd_path
         };

--- a/crates/agent-vessel/src/types.rs
+++ b/crates/agent-vessel/src/types.rs
@@ -42,7 +42,7 @@ impl VesselConfig {
     /// Create config using GITHUB_PERSONAL_ACCESS_TOKEN (fallback).
     pub fn from_env() -> Self {
         let github_token = std::env::var("GITHUB_PERSONAL_ACCESS_TOKEN")
-            .expect("GITHUB_PERSONAL_ACCESS_TOKEN must be set");
+            .expect("GITHUB_PERSONAL_ACCESS_TOKEN (or AGENT_VESSEL_GITHUB_TOKEN via registry) must be set");
 
         Self {
             ci_poll: CiPollConfig::default(),

--- a/crates/agent-vessel/src/types.rs
+++ b/crates/agent-vessel/src/types.rs
@@ -41,8 +41,9 @@ impl VesselConfig {
 
     /// Create config using GITHUB_PERSONAL_ACCESS_TOKEN (fallback).
     pub fn from_env() -> Self {
-        let github_token = std::env::var("GITHUB_PERSONAL_ACCESS_TOKEN")
-            .expect("GITHUB_PERSONAL_ACCESS_TOKEN (or AGENT_VESSEL_GITHUB_TOKEN via registry) must be set");
+        let github_token = std::env::var("GITHUB_PERSONAL_ACCESS_TOKEN").expect(
+            "GITHUB_PERSONAL_ACCESS_TOKEN (or AGENT_VESSEL_GITHUB_TOKEN via registry) must be set",
+        );
 
         Self {
             ci_poll: CiPollConfig::default(),


### PR DESCRIPTION
…ME first

- agentflow.rs: Use VesselConfig::from_registry() with the resolver path instead of VesselNode::from_env() which searched only CWD
- VesselNode::from_env(): Search OPENFLOWS_HOME first for registry, then workspace root, then CWD — same priority as OrchestrationResolver
- VesselConfig::from_env(): Improved error message to mention per-agent tokens as well as global PAT