### PR TITLE
fix: use dynamic token-based GitHub identity resolution for issue assignment

### DIFF
--- a/crates/agent-nexus/src/lib.rs
+++ b/crates/agent-nexus/src/lib.rs
@@ -22,6 +22,7 @@ const MAX_CONFLICT_RESOLUTION_ATTEMPTS: u32 = 3;
 /// Must match vessel::node::MAX_CI_FIX_ATTEMPTS to stay in sync.
 const MAX_CI_FIX_ATTEMPTS_NEXUS: u32 = 3;
 const CI_SETUP_TICKET_ID: &str = "T-CI-001";
+const ASSIGNMENT_FAILURE_MARKER: &str = "<!-- openflows-assignment-failure -->";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -591,6 +592,41 @@ impl NexusNode {
         }
     }
 
+    /// Post a diagnostic comment on a GitHub issue only if no comment with the
+    /// given marker tag already exists. This prevents spamming the same issue
+    /// across multiple nexus cycles when assignment consistently fails.
+    async fn post_comment_once(
+        client: &github::GithubRestClient,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        marker: &str,
+        comment: &str,
+    ) {
+        match client
+            .issue_has_comment_with_marker(owner, repo, issue_number, marker)
+            .await
+        {
+            Ok(true) => {
+                info!(owner, repo, issue_number, "Assignment-failure comment already exists — skipping");
+            }
+            Ok(false) => {
+                if let Err(ce) = client.comment_on_issue(owner, repo, issue_number, comment).await {
+                    warn!(error = %ce, "Failed to post assignment-failure comment on issue");
+                }
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "Failed to check for existing assignment-failure comment — posting anyway"
+                );
+                if let Err(ce) = client.comment_on_issue(owner, repo, issue_number, comment).await {
+                    warn!(error = %ce, "Failed to post assignment-failure comment on issue");
+                }
+            }
+        }
+    }
+
     /// Sync work assignment to GitHub by assigning the issue to the worker.
     /// The worker's GitHub username is resolved dynamically by calling the GitHub API
     /// (GET /user) with the worker's token, which is more robust than reading a static
@@ -654,6 +690,35 @@ impl NexusNode {
         let identity_manager = config::IdentityManager::load(&self.registry_path)
             .context("Failed to load IdentityManager from registry")?;
 
+        let registry = identity_manager
+            .registry()
+            .context("Failed to read registry for worker token check")?;
+
+        let base_id = registry.normalize_agent_id(worker_id);
+        #[allow(clippy::needless_borrow)]
+        let worker_entry = registry.get(&base_id);
+
+        let has_dedicated_token = worker_entry
+            .as_ref()
+            .map(|e| e.github_token_env.is_some())
+            .unwrap_or(false);
+
+        if !has_dedicated_token {
+            warn!(
+                worker_id,
+                "Worker has no dedicated github_token_env — cannot safely determine its GitHub identity"
+            );
+            let comment = format!(
+                "<!-- openflows-assignment-failure -->\n\
+                 ⚠️ **Could not assign this issue to `{}`** — the agent does not have a dedicated \
+                 GitHub token configured. Please add a `github_token_env` field for this agent in \
+                 `registry.json` so its identity can be resolved dynamically.",
+                worker_id
+            );
+            Self::post_comment_once(&nexus_client, owner, repo, issue_number, ASSIGNMENT_FAILURE_MARKER, &comment).await;
+            return Ok(());
+        }
+
         let worker_token_result = identity_manager.resolve_github_token(worker_id);
         if let Err(e) = &worker_token_result {
             warn!(
@@ -661,14 +726,17 @@ impl NexusNode {
                 error = %e,
                 "Failed to resolve GitHub token for worker"
             );
+            let env_var_name = worker_entry
+                .as_ref()
+                .and_then(|e| e.github_token_env.as_deref())
+                .unwrap_or("<missing>");
             let comment = format!(
-                "⚠️ **Could not assign this issue to `{}`** — the agent's GitHub token is not configured. \
-                 Please check that `github_token_env` is set correctly in the registry for this agent.",
-                worker_id
+                "<!-- openflows-assignment-failure -->\n\
+                 ⚠️ **Could not assign this issue to `{}`** — the agent's GitHub token environment \
+                 variable is not set. Please check that `{}` is configured in the environment.",
+                worker_id, env_var_name
             );
-            if let Err(ce) = nexus_client.comment_on_issue(owner, repo, issue_number, &comment).await {
-                warn!(worker_id, ticket_id, error = %ce, "Failed to post assignment-failure comment on issue");
-            }
+            Self::post_comment_once(&nexus_client, owner, repo, issue_number, ASSIGNMENT_FAILURE_MARKER, &comment).await;
             return Ok(());
         }
 
@@ -682,14 +750,13 @@ impl NexusNode {
                 "Failed to resolve GitHub username from worker token"
             );
             let comment = format!(
-                "⚠️ **Could not assign this issue to `{}`** — failed to look up the agent's GitHub identity via the API. \
-                 This usually means the agent's GitHub token is invalid or expired. \
-                 Error: {}",
+                "<!-- openflows-assignment-failure -->\n\
+                 ⚠️ **Could not assign this issue to `{}`** — failed to look up the agent's GitHub \
+                 identity via the API. This usually means the agent's GitHub token is invalid or \
+                 expired.\n\nError: {}",
                 worker_id, e
             );
-            if let Err(ce) = nexus_client.comment_on_issue(owner, repo, issue_number, &comment).await {
-                warn!(worker_id, ticket_id, error = %ce, "Failed to post assignment-failure comment on issue");
-            }
+            Self::post_comment_once(&nexus_client, owner, repo, issue_number, ASSIGNMENT_FAILURE_MARKER, &comment).await;
             return Ok(());
         }
 
@@ -713,13 +780,13 @@ impl NexusNode {
                             github_username
                         );
                         let comment = format!(
-                            "⚠️ **Could not assign this issue to `@{}`** — this GitHub user is not a collaborator on `{}/{}`. \
-                             To fix this, add `{}` as a collaborator or adjust repository permissions.",
+                            "<!-- openflows-assignment-failure -->\n\
+                             ⚠️ **Could not assign this issue to `@{}`** — this GitHub user is not a \
+                             collaborator on `{}/{}`. To fix this, add `{}` as a collaborator or \
+                             adjust repository permissions.",
                             github_username, owner, repo, github_username
                         );
-                        if let Err(ce) = nexus_client.comment_on_issue(owner, repo, issue_number, &comment).await {
-                            warn!(worker_id, ticket_id, error = %ce, "Failed to post assignment-failure comment on issue");
-                        }
+                        Self::post_comment_once(&nexus_client, owner, repo, issue_number, ASSIGNMENT_FAILURE_MARKER, &comment).await;
                         (github_username.clone(), false)
                     } else {
                         return Err(e);

--- a/crates/agent-nexus/src/lib.rs
+++ b/crates/agent-nexus/src/lib.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use config::{
     state::{KEY_COMMAND_GATE, KEY_PENDING_PRS, KEY_TICKETS, KEY_WORKER_SLOTS},
-    AgentDef, Registry, Ticket, TicketStatus, WorkerSlot, WorkerStatus, ACTION_MERGE_PRS,
+    Registry, Ticket, TicketStatus, WorkerSlot, WorkerStatus, ACTION_MERGE_PRS,
     ACTION_NO_WORK,
 };
 use pocketflow_core::{node::STOP_SIGNAL, Action, Node, SharedStore};
@@ -591,20 +591,22 @@ impl NexusNode {
         }
     }
 
-    /// Sync work assignment to GitHub by assigning the issue to the forge worker.
-    /// The forge worker's GitHub username is loaded from the agent definition (forge.agent.md).
+    /// Sync work assignment to GitHub by assigning the issue to the worker.
+    /// The worker's GitHub username is resolved dynamically by calling the GitHub API
+    /// (GET /user) with the worker's token, which is more robust than reading a static
+    /// field from the agent definition and works across repos where the bot is a member.
+    ///
+    /// If identity resolution fails, a helpful comment is posted on the issue instead
+    /// of silently skipping assignment.
     async fn sync_assignment_to_github(
         &self,
         worker_id: &str,
         ticket_id: &str,
         issue_url: &str,
     ) -> Result<()> {
-        // Parse owner/repo from issue URL and extract issue number
-        // Expected format: https://github.com/{owner}/{repo}/issues/{number}
         let parsed_url = url::Url::parse(issue_url)
             .with_context(|| format!("Invalid issue URL format: {}", issue_url))?;
 
-        // Validate host is github.com (case-insensitive)
         let host = parsed_url
             .host_str()
             .ok_or_else(|| anyhow::anyhow!("Missing host in URL"))?;
@@ -612,7 +614,6 @@ impl NexusNode {
             anyhow::bail!("URL host must be github.com, got: {}", host);
         }
 
-        // Parse path segments: /{owner}/{repo}/issues/{number}
         let path_segments: Vec<&str> = parsed_url
             .path_segments()
             .map(|s| s.collect::<Vec<_>>())
@@ -625,7 +626,6 @@ impl NexusNode {
             );
         }
 
-        // Check that the third segment is "issues" (or "pull" for PRs)
         let issue_type = path_segments[2];
         if issue_type != "issues" && issue_type != "pull" {
             anyhow::bail!(
@@ -637,114 +637,102 @@ impl NexusNode {
         let owner = path_segments[0];
         let repo = path_segments[1];
 
-        // Extract issue number, stripping any trailing slashes or query parameters
         let number_str = path_segments[3].trim_end_matches('/');
         let issue_number: u64 = number_str
             .parse()
             .with_context(|| format!("Could not parse issue number from: {}", number_str))?;
 
-        let token = match self.resolve_github_token() {
+        let nexus_token = match self.resolve_github_token() {
             Ok(t) => t,
             Err(e) => {
-                anyhow::bail!("GitHub token not configured: {}", e);
+                anyhow::bail!("GitHub token not configured for nexus: {}", e);
             }
         };
 
-        let client = github::GithubRestClient::new(&token);
+        let nexus_client = github::GithubRestClient::new(&nexus_token);
 
-        // Load the agent definition to get the GitHub username for the worker
-        // Worker IDs are typically in format "forge-1", "forge-2", etc.
-        let agent_type = worker_id.split('-').next().unwrap_or("forge");
-        let agent_def_path = self
-            .registry_path
-            .parent()
-            .map(|p| p.join("agents").join(format!("{}.agent.md", agent_type)))
-            .unwrap_or_else(|| {
-                PathBuf::from(format!(
-                    "orchestration/agent/agents/{}.agent.md",
-                    agent_type
-                ))
-            });
+        let identity_manager = config::IdentityManager::load(&self.registry_path)
+            .context("Failed to load IdentityManager from registry")?;
 
-        let github_username = match AgentDef::load(&agent_def_path) {
-            Ok(def) => def.github.trim().to_string(),
-            Err(e) => {
-                warn!(
-                    worker_id,
-                    agent_type,
-                    path = %agent_def_path.display(),
-                    error = %e,
-                    "Failed to load agent definition — using empty GitHub username"
-                );
-                String::new()
+        let worker_token_result = identity_manager.resolve_github_token(worker_id);
+        if let Err(e) = &worker_token_result {
+            warn!(
+                worker_id,
+                error = %e,
+                "Failed to resolve GitHub token for worker"
+            );
+            let comment = format!(
+                "⚠️ **Could not assign this issue to `{}`** — the agent's GitHub token is not configured. \
+                 Please check that `github_token_env` is set correctly in the registry for this agent.",
+                worker_id
+            );
+            if let Err(ce) = nexus_client.comment_on_issue(owner, repo, issue_number, &comment).await {
+                warn!(worker_id, ticket_id, error = %ce, "Failed to post assignment-failure comment on issue");
             }
-        };
+            return Ok(());
+        }
 
-        // Only attempt assignment if a valid GitHub username is configured
-        let (assignee_display, assignment_success) = if !github_username.is_empty() {
-            match client
+        let worker_token = worker_token_result.unwrap();
+        let worker_client = github::GithubRestClient::new(&worker_token);
+        let username_result = worker_client.get_authenticated_user_login().await;
+        if let Err(e) = &username_result {
+            warn!(
+                worker_id,
+                error = %e,
+                "Failed to resolve GitHub username from worker token"
+            );
+            let comment = format!(
+                "⚠️ **Could not assign this issue to `{}`** — failed to look up the agent's GitHub identity via the API. \
+                 This usually means the agent's GitHub token is invalid or expired. \
+                 Error: {}",
+                worker_id, e
+            );
+            if let Err(ce) = nexus_client.comment_on_issue(owner, repo, issue_number, &comment).await {
+                warn!(worker_id, ticket_id, error = %ce, "Failed to post assignment-failure comment on issue");
+            }
+            return Ok(());
+        }
+
+        let github_username = username_result.unwrap();
+
+        let (assignee_display, assignment_success) =
+            match nexus_client
                 .assign_issue(owner, repo, issue_number, &github_username)
                 .await
             {
                 Ok(_) => (github_username.clone(), true),
                 Err(e) => {
                     let err_str = e.to_string();
-                    // Check if it's a validation error (422) for invalid assignee
                     if err_str.starts_with("Validation failed (422)") {
                         warn!(
                             worker_id,
                             ticket_id,
                             github_username,
                             error = %e,
-                            "GitHub user '{}' is not a valid assignee for this repository — skipping assignment",
+                            "GitHub user '{}' is not a valid assignee for this repository",
                             github_username
                         );
-                        // Continue without failing - assignment is not critical
+                        let comment = format!(
+                            "⚠️ **Could not assign this issue to `@{}`** — this GitHub user is not a collaborator on `{}/{}`. \
+                             To fix this, add `{}` as a collaborator or adjust repository permissions.",
+                            github_username, owner, repo, github_username
+                        );
+                        if let Err(ce) = nexus_client.comment_on_issue(owner, repo, issue_number, &comment).await {
+                            warn!(worker_id, ticket_id, error = %ce, "Failed to post assignment-failure comment on issue");
+                        }
                         (github_username.clone(), false)
                     } else {
                         return Err(e);
                     }
                 }
-            }
-        } else {
-            warn!(
-                worker_id,
-                ticket_id, "No GitHub username configured for worker — skipping assignment"
-            );
-            ("<none>".to_string(), false)
-        };
+            };
 
         if assignment_success {
-            #[cfg(debug_assertions)]
-            info!(
-                worker_id,
-                ticket_id,
-                issue_url,
-                assignee = assignee_display,
-                "Successfully synced assignment to GitHub"
-            );
-            #[cfg(not(debug_assertions))]
             info!(
                 worker_id,
                 ticket_id,
                 assignee = assignee_display,
                 "Successfully synced assignment to GitHub"
-            );
-        } else {
-            #[cfg(debug_assertions)]
-            info!(
-                worker_id,
-                ticket_id,
-                issue_url,
-                attempted_assignee = assignee_display,
-                "GitHub assignment skipped (not critical)"
-            );
-            #[cfg(not(debug_assertions))]
-            info!(
-                worker_id,
-                ticket_id,
-                attempted_assignee = assignee_display,
-                "GitHub assignment skipped (not critical)"
             );
         }
 

--- a/crates/agent-nexus/src/lib.rs
+++ b/crates/agent-nexus/src/lib.rs
@@ -4,8 +4,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use config::{
     state::{KEY_COMMAND_GATE, KEY_PENDING_PRS, KEY_TICKETS, KEY_WORKER_SLOTS},
-    Registry, Ticket, TicketStatus, WorkerSlot, WorkerStatus, ACTION_MERGE_PRS,
-    ACTION_NO_WORK,
+    Registry, Ticket, TicketStatus, WorkerSlot, WorkerStatus, ACTION_MERGE_PRS, ACTION_NO_WORK,
 };
 use pocketflow_core::{node::STOP_SIGNAL, Action, Node, SharedStore};
 use serde::{Deserialize, Serialize};
@@ -608,10 +607,16 @@ impl NexusNode {
             .await
         {
             Ok(true) => {
-                info!(owner, repo, issue_number, "Assignment-failure comment already exists — skipping");
+                info!(
+                    owner,
+                    repo, issue_number, "Assignment-failure comment already exists — skipping"
+                );
             }
             Ok(false) => {
-                if let Err(ce) = client.comment_on_issue(owner, repo, issue_number, comment).await {
+                if let Err(ce) = client
+                    .comment_on_issue(owner, repo, issue_number, comment)
+                    .await
+                {
                     warn!(error = %ce, "Failed to post assignment-failure comment on issue");
                 }
             }
@@ -620,7 +625,10 @@ impl NexusNode {
                     error = %e,
                     "Failed to check for existing assignment-failure comment — posting anyway"
                 );
-                if let Err(ce) = client.comment_on_issue(owner, repo, issue_number, comment).await {
+                if let Err(ce) = client
+                    .comment_on_issue(owner, repo, issue_number, comment)
+                    .await
+                {
                     warn!(error = %ce, "Failed to post assignment-failure comment on issue");
                 }
             }
@@ -715,7 +723,15 @@ impl NexusNode {
                  `registry.json` so its identity can be resolved dynamically.",
                 worker_id
             );
-            Self::post_comment_once(&nexus_client, owner, repo, issue_number, ASSIGNMENT_FAILURE_MARKER, &comment).await;
+            Self::post_comment_once(
+                &nexus_client,
+                owner,
+                repo,
+                issue_number,
+                ASSIGNMENT_FAILURE_MARKER,
+                &comment,
+            )
+            .await;
             return Ok(());
         }
 
@@ -736,7 +752,15 @@ impl NexusNode {
                  variable is not set. Please check that `{}` is configured in the environment.",
                 worker_id, env_var_name
             );
-            Self::post_comment_once(&nexus_client, owner, repo, issue_number, ASSIGNMENT_FAILURE_MARKER, &comment).await;
+            Self::post_comment_once(
+                &nexus_client,
+                owner,
+                repo,
+                issue_number,
+                ASSIGNMENT_FAILURE_MARKER,
+                &comment,
+            )
+            .await;
             return Ok(());
         }
 
@@ -756,43 +780,58 @@ impl NexusNode {
                  expired.\n\nError: {}",
                 worker_id, e
             );
-            Self::post_comment_once(&nexus_client, owner, repo, issue_number, ASSIGNMENT_FAILURE_MARKER, &comment).await;
+            Self::post_comment_once(
+                &nexus_client,
+                owner,
+                repo,
+                issue_number,
+                ASSIGNMENT_FAILURE_MARKER,
+                &comment,
+            )
+            .await;
             return Ok(());
         }
 
         let github_username = username_result.unwrap();
 
-        let (assignee_display, assignment_success) =
-            match nexus_client
-                .assign_issue(owner, repo, issue_number, &github_username)
-                .await
-            {
-                Ok(_) => (github_username.clone(), true),
-                Err(e) => {
-                    let err_str = e.to_string();
-                    if err_str.starts_with("Validation failed (422)") {
-                        warn!(
-                            worker_id,
-                            ticket_id,
-                            github_username,
-                            error = %e,
-                            "GitHub user '{}' is not a valid assignee for this repository",
-                            github_username
-                        );
-                        let comment = format!(
+        let (assignee_display, assignment_success) = match nexus_client
+            .assign_issue(owner, repo, issue_number, &github_username)
+            .await
+        {
+            Ok(_) => (github_username.clone(), true),
+            Err(e) => {
+                let err_str = e.to_string();
+                if err_str.starts_with("Validation failed (422)") {
+                    warn!(
+                        worker_id,
+                        ticket_id,
+                        github_username,
+                        error = %e,
+                        "GitHub user '{}' is not a valid assignee for this repository",
+                        github_username
+                    );
+                    let comment = format!(
                             "<!-- openflows-assignment-failure -->\n\
                              ⚠️ **Could not assign this issue to `@{}`** — this GitHub user is not a \
                              collaborator on `{}/{}`. To fix this, add `{}` as a collaborator or \
                              adjust repository permissions.",
                             github_username, owner, repo, github_username
                         );
-                        Self::post_comment_once(&nexus_client, owner, repo, issue_number, ASSIGNMENT_FAILURE_MARKER, &comment).await;
-                        (github_username.clone(), false)
-                    } else {
-                        return Err(e);
-                    }
+                    Self::post_comment_once(
+                        &nexus_client,
+                        owner,
+                        repo,
+                        issue_number,
+                        ASSIGNMENT_FAILURE_MARKER,
+                        &comment,
+                    )
+                    .await;
+                    (github_username.clone(), false)
+                } else {
+                    return Err(e);
                 }
-            };
+            }
+        };
 
         if assignment_success {
             info!(

--- a/crates/github/src/rest.rs
+++ b/crates/github/src/rest.rs
@@ -739,6 +739,68 @@ impl GithubRestClient {
         self.get_json(&url).await
     }
 
+    /// Get the authenticated user's login name using the current token.
+    /// Calls GET /user and returns the "login" field.
+    pub async fn get_authenticated_user_login(&self) -> Result<String> {
+        let url = format!("{}/user", GITHUB_API_BASE);
+        let resp = self.send_with_retry(|| self.build_get(&url)).await?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body_text = resp.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "Failed to get authenticated user (status {}): {}",
+                status,
+                body_text
+            );
+        }
+
+        let user: serde_json::Value = resp
+            .json()
+            .await
+            .context("Failed to parse GitHub user response")?;
+
+        let login = user["login"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("GitHub user response missing 'login' field"))?;
+
+        Ok(login.to_string())
+    }
+
+    /// Post a comment on a GitHub issue.
+    pub async fn comment_on_issue(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        comment_body: &str,
+    ) -> Result<()> {
+        let url = format!(
+            "{}/repos/{}/{}/issues/{}/comments",
+            GITHUB_API_BASE, owner, repo, issue_number
+        );
+        let payload = serde_json::json!({ "body": comment_body });
+        let body_bytes = serde_json::to_vec(&payload)?;
+
+        let resp = self
+            .send_with_retry(|| self.build_post(&url, &body_bytes))
+            .await?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body_text = resp.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "Failed to post comment on issue #{} (status {}): {}",
+                issue_number,
+                status,
+                body_text
+            );
+        }
+
+        info!(owner, repo, issue = issue_number, "Comment posted on GitHub issue");
+        Ok(())
+    }
+
     /// Assign a GitHub issue to a user.
     /// The assignee should be a GitHub username (e.g., "forge-bot").
     /// Returns Ok(()) on success, or an error with the HTTP status code on failure.

--- a/crates/github/src/rest.rs
+++ b/crates/github/src/rest.rs
@@ -819,7 +819,12 @@ impl GithubRestClient {
             );
         }
 
-        info!(owner, repo, issue = issue_number, "Comment posted on GitHub issue");
+        info!(
+            owner,
+            repo,
+            issue = issue_number,
+            "Comment posted on GitHub issue"
+        );
         Ok(())
     }
 

--- a/crates/github/src/rest.rs
+++ b/crates/github/src/rest.rs
@@ -767,6 +767,28 @@ impl GithubRestClient {
         Ok(login.to_string())
     }
 
+    /// Check whether a diagnostic comment with the given marker tag already exists on an issue.
+    /// The marker is an HTML comment like `<!-- openflows-assignment-failure -->` embedded in the body.
+    pub async fn issue_has_comment_with_marker(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        marker: &str,
+    ) -> Result<bool> {
+        let url = format!(
+            "{}/repos/{}/{}/issues/{}/comments?per_page=100",
+            GITHUB_API_BASE, owner, repo, issue_number
+        );
+        let comments: Vec<serde_json::Value> = self.get_json(&url).await?;
+        Ok(comments.iter().any(|c| {
+            c["body"]
+                .as_str()
+                .map(|b| b.contains(marker))
+                .unwrap_or(false)
+        }))
+    }
+
     /// Post a comment on a GitHub issue.
     pub async fn comment_on_issue(
         &self,


### PR DESCRIPTION
## Summary

Replaces the static  `github` field lookup in nexus agent's `sync_assignment_to_github()` with dynamic token-based username resolution via `IdentityManager` + `GithubRestClient::get_authenticated_user_login()`.

### Problem
The nexus agent was reading the worker's GitHub username from the `github` field in `.agent.md` files. This was fragile:
- Format inconsistency: some agents used flat strings (`forge-openflows`), others used nested objects (`username: nexus-bot`)
- Hardcoded usernames fail on repos where the bot isn't an explicit member (422 errors)
- The `AgentDef::parse()` method expected a flat string, so nested formats silently broke

### Changes

**`crates/github/src/rest.rs`**
- Added `get_authenticated_user_login()` — calls `GET /user` with the client's token and returns the `login` field
- Added `comment_on_issue()` — posts a comment on a GitHub issue for diagnostic feedback

**`crates/agent-nexus/src/lib.rs`**
- `sync_assignment_to_github()` now uses `IdentityManager` to resolve the worker's GitHub token, then calls `get_authenticated_user_login()` to dynamically discover the username
- Removed `AgentDef` import (no longer needed)
- Removed `PathBuf` dependency on agent definition files
- On **token not configured**: posts a comment on the issue explaining the misconfiguration
- On **username lookup failure**: posts a comment with the error details
- On **422 invalid assignee**: posts a comment suggesting adding the user as a collaborator
- Removed `#[cfg(debug_assertions)]` conditional logging — single `info!` for success path
- No fallback to nexus token — if worker identity can't be resolved, assignment is skipped gracefully with an explanatory comment

### Testing
- `cargo check -p agent-nexus -p github` ✓
- `cargo test -p agent-nexus -p config -p github` ✓
- `cargo clippy -p agent-nexus -p github` ✓