### PR TITLE
fix: sentinel --sandbox flag for Claude backend + inotify fallback (v1.1.8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openflows"
-version = "1.0.16"
+version = "1.1.8"
 dependencies = [
  "agent-forge",
  "agent-lore",

--- a/binary/Cargo.toml
+++ b/binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "openflows"
-version = "1.1.6"
+version = "1.1.8"
 edition = "2021"
 license = "MIT"
 

--- a/crates/pair-harness/src/process.rs
+++ b/crates/pair-harness/src/process.rs
@@ -1331,7 +1331,19 @@ trust_level = "trusted"
             cmd.arg("--sandbox");
             cmd.arg("workspace-write");
         } else {
+            // Claude base_flags includes `--output-format stream-json`, but sentinel
+            // needs `--output-format json` (from sentinel_flags). Skip the base value
+            // to avoid emitting the flag twice with conflicting values.
+            let mut skip_next = false;
             for arg in &config.base_flags {
+                if skip_next {
+                    skip_next = false;
+                    continue;
+                }
+                if arg == "--output-format" {
+                    skip_next = true;
+                    continue;
+                }
                 cmd.arg(arg);
             }
         }

--- a/crates/pair-harness/src/process.rs
+++ b/crates/pair-harness/src/process.rs
@@ -1320,14 +1320,21 @@ trust_level = "trusted"
         let config = self.get_backend(backend);
         let mut cmd = Command::new(&config.binary_path);
 
-        // SENTINEL uses workspace-write sandbox — it needs to write review files
-        // to the shared directory and needs GitHub API access for posting review
-        // comments, but should NOT have full filesystem access like FORGE.
-        // FORGE uses danger-full-access (set in base_flags) because it needs
-        // git push and full filesystem access for code changes.
-        cmd.arg("exec");
-        cmd.arg("--sandbox");
-        cmd.arg("workspace-write");
+        // Codex SENTINEL uses workspace-write sandbox — it needs to write review
+        // files to the shared directory and needs GitHub API access for posting
+        // review comments, but should NOT have full filesystem access like FORGE.
+        // Claude SENTINEL uses base_flags (--dangerously-skip-permissions, etc.)
+        // and sentinel_flags (--output-format json, --no-session-persistence).
+        // The --sandbox flag only exists in the Codex CLI.
+        if backend == CliBackend::Codex {
+            cmd.arg("exec");
+            cmd.arg("--sandbox");
+            cmd.arg("workspace-write");
+        } else {
+            for arg in &config.base_flags {
+                cmd.arg(arg);
+            }
+        }
 
         // Pass model from ProcessManager's model_backend override (from registry.json)
         // or fall back to the backend-specific env var (OPENAI_MODEL, ANTHROPIC_MODEL, etc.)

--- a/crates/pair-harness/src/watcher.rs
+++ b/crates/pair-harness/src/watcher.rs
@@ -2,22 +2,30 @@
 //! Filesystem watcher for event-driven harness.
 //!
 //! Uses notify crate for cross-platform inotify/FSEvents support.
+//! Falls back to polling when inotify watch limits are exhausted.
 
 use crate::types::FsEvent;
 use anyhow::{Context, Result};
-use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::{Config, Event, EventKind, PollWatcher, RecommendedWatcher, RecursiveMode, Watcher};
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::time::{Duration, Instant};
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 const DEBOUNCE_MS: u64 = 500;
+const POLL_INTERVAL_MS: u64 = 500;
+
+#[allow(dead_code)]
+enum WatcherInner {
+    Recommended(RecommendedWatcher),
+    Poll(PollWatcher),
+}
 
 /// Watches the shared directory for file changes.
 pub struct SharedDirWatcher {
     /// The underlying notify watcher (must be kept alive)
-    _watcher: RecommendedWatcher,
+    _watcher: WatcherInner,
     /// Receiver for filesystem events
     receiver: Receiver<FsEvent>,
     /// Last seen timestamps for debouncing
@@ -38,9 +46,20 @@ impl SharedDirWatcher {
         })
     }
 
-    /// Create and configure the notify watcher.
-    fn create_watcher(tx: Sender<FsEvent>, shared_dir: &Path) -> Result<RecommendedWatcher> {
-        // Create a watcher with a callback
+    /// Create and configure the notify watcher, falling back to PollWatcher
+    /// if the RecommendedWatcher (inotify/FSEvents) cannot be started due to
+    /// OS resource limits (e.g. inotify max_user_watches exhausted on Linux).
+    fn create_watcher(tx: Sender<FsEvent>, shared_dir: &Path) -> Result<WatcherInner> {
+        match Self::try_recommended_watcher(tx.clone(), shared_dir) {
+            Ok(w) => Ok(w),
+            Err(e) => {
+                warn!(error = %e, "RecommendedWatcher failed, falling back to PollWatcher");
+                Self::create_poll_watcher(tx, shared_dir)
+            }
+        }
+    }
+
+    fn try_recommended_watcher(tx: Sender<FsEvent>, shared_dir: &Path) -> Result<WatcherInner> {
         let mut watcher = notify::recommended_watcher(move |res: notify::Result<Event>| {
             match res {
                 Ok(event) => {
@@ -65,8 +84,37 @@ impl SharedDirWatcher {
             .watch(shared_dir, RecursiveMode::NonRecursive)
             .context("Failed to start watching shared directory")?;
 
-        debug!(path = %shared_dir.display(), "Started watching shared directory");
-        Ok(watcher)
+        debug!(path = %shared_dir.display(), "Started watching shared directory (inotify)");
+        Ok(WatcherInner::Recommended(watcher))
+    }
+
+    fn create_poll_watcher(tx: Sender<FsEvent>, shared_dir: &Path) -> Result<WatcherInner> {
+        let config = Config::default()
+            .with_poll_interval(Duration::from_millis(POLL_INTERVAL_MS));
+
+        let mut watcher = PollWatcher::new(
+            move |res: notify::Result<Event>| {
+                match res {
+                    Ok(event) => {
+                        if let Some(fs_event) = Self::classify_event(&event) {
+                            debug!(event = ?fs_event, paths = ?event.paths, "Filesystem event detected (poll)");
+                            let _ = tx.send(fs_event);
+                        }
+                    }
+                    Err(e) => {
+                        error!(error = %e, "Poll watch error");
+                    }
+                }
+            },
+            config,
+        ).context("Failed to create poll filesystem watcher")?;
+
+        watcher
+            .watch(shared_dir, RecursiveMode::NonRecursive)
+            .context("Failed to start polling shared directory")?;
+
+        debug!(path = %shared_dir.display(), "Started watching shared directory (polling fallback)");
+        Ok(WatcherInner::Poll(watcher))
     }
 
     /// Classify a filesystem event into our FsEvent type.

--- a/crates/pair-harness/src/watcher.rs
+++ b/crates/pair-harness/src/watcher.rs
@@ -89,8 +89,7 @@ impl SharedDirWatcher {
     }
 
     fn create_poll_watcher(tx: Sender<FsEvent>, shared_dir: &Path) -> Result<WatcherInner> {
-        let config = Config::default()
-            .with_poll_interval(Duration::from_millis(POLL_INTERVAL_MS));
+        let config = Config::default().with_poll_interval(Duration::from_millis(POLL_INTERVAL_MS));
 
         let mut watcher = PollWatcher::new(
             move |res: notify::Result<Event>| {


### PR DESCRIPTION
## Bug Fixes

### 1. Sentinel `--sandbox` flag error for Claude backend

`build_sentinel_command` always passed `--sandbox workspace-write` regardless of CLI backend. The `--sandbox` flag only exists in the Codex CLI — Claude CLI does not understand it, causing `error: unknown option '--sandbox'` and immediate sentinel exit.

**Fix:** \`build_sentinel_command\` now checks the backend type:
- **Codex:** uses `exec --sandbox workspace-write` (unchanged)
- **Claude:** uses `base_flags` (`--print --dangerously-skip-permissions --output-format stream-json --verbose`) + `sentinel_flags` (`--output-format json --no-session-persistence`)

### 2. Inotify watch limit crash

`SharedDirWatcher` used `notify::recommended_watcher` (inotify) exclusively. When `fs.inotify.max_user_watches` is exhausted, the watcher fails with `OS file watch limit reached` and kills the entire forge-sentinel pair lifecycle.

**Fix:** Falls back to `PollWatcher` (500ms interval) when inotify initialization fails, with a log warning.

### Version

Bumps binary version to **1.1.8**.