### PR TITLE
release: v1.1.8 — fix worker workspaces booting without openflows-harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openflows"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "agent-forge",
  "agent-lore",

--- a/binary/Cargo.toml
+++ b/binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "openflows"
-version = "1.1.6"
+version = "1.1.8"
 edition = "2021"
 license = "MIT"
 

--- a/crates/coder-client/templates/openflows-forge/main.tf
+++ b/crates/coder-client/templates/openflows-forge/main.tf
@@ -16,7 +16,7 @@ variable "dev_binary_host_path" {
 
 variable "harness_version" {
   type        = string
-  default     = "1.1.6"
+  default     = "1.1.8"
   description = "openflows-harness binary version to download"
 }
 

--- a/crates/coder-client/templates/openflows-lore/main.tf
+++ b/crates/coder-client/templates/openflows-lore/main.tf
@@ -42,7 +42,7 @@ variable "coder_url" {
 
 variable "harness_version" {
   type        = string
-  default     = "1.1.6"
+  default     = "1.1.8"
   description = "openflows-harness binary version to download"
 }
 

--- a/crates/coder-client/templates/openflows-sentinel/main.tf
+++ b/crates/coder-client/templates/openflows-sentinel/main.tf
@@ -42,7 +42,7 @@ variable "coder_url" {
 
 variable "harness_version" {
   type        = string
-  default     = "1.1.6"
+  default     = "1.1.8"
   description = "openflows-harness binary version to download"
 }
 

--- a/crates/coder-client/templates/openflows-vessel/main.tf
+++ b/crates/coder-client/templates/openflows-vessel/main.tf
@@ -36,7 +36,7 @@ variable "tenant" {
 
 variable "harness_version" {
   type        = string
-  default     = "1.1.6"
+  default     = "1.1.8"
   description = "openflows-harness binary version to download"
 }
 


### PR DESCRIPTION
## Problem

Worker workspaces (Sentinel, Forge, Vessel, Lore) are booting with **no `openflows-harness` binary** and being handed ticket dispatch anyway. Observed directly on the T-047 and T-048 Sentinel sessions — `openflows-harness: not found` for every subcommand.

## Root cause

- `gh release list --repo The-AgenticFlow/openflows` returns **zero releases**, and `gh api repos/.../releases` confirms it (`[]`).
- A release for `v1.1.7` (id `342816806`) *was* successfully created and had all platform tarballs uploaded on 2026-06-22 (confirmed via the archived `Create Release` job log), but it no longer exists via the API — it was removed at some point after creation.
- Every worker template's `startup_script` (`crates/coder-client/templates/openflows-{forge,sentinel,vessel,lore}/main.tf`) downloads the harness binary from a pinned-version GitHub release tarball URL. With no release present, that `curl` 404s.
- The script only logs a `WARNING: Failed to download openflows-harness — agent will not be able to coordinate` and **continues** — the workspace boots successfully with the harness missing, and nothing downstream checks for this before assigning work.

## Fix in this PR

- Bump `binary/Cargo.toml` version `1.1.6` → `1.1.8` so the `Release` workflow (triggered by the `v1.1.8` tag push after this merges) builds and publishes a fresh `openflows-harness` binary.
- Bump `harness_version` default in all four worker templates from `1.1.6` → `1.1.8` so newly provisioned workspaces point at the release that will actually exist.

## Not in this PR (tracked as follow-up)

The silent-degradation behavior itself — worker templates warning-and-continuing instead of failing hard (or blocking ticket dispatch) when the harness download fails — is the systemic issue that let this go unnoticed. That hardening is a separate change and is intentionally not bundled into this release-unblocking fix.

## Verification

- `cargo check -p openflows` passes with the version bump; `coder-client`'s build script regenerates the Coder template archives from the updated `.tf` sources.
- After merge, tagging `v1.1.8` and pushing the tag will trigger `.github/workflows/release.yml`, which builds `openflows-harness` for `x86_64-unknown-linux-musl` (the platform the templates fetch) among others, and publishes the GitHub Release the templates' `curl` call depends on.
