### PR TITLE
fix(release): only build binaries that exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,15 +133,13 @@ jobs:
         if: matrix.use_zigbuild
         run: pip3 install cargo-zigbuild ziglang
 
-      - name: Build binaries
-        run: >
-          ${{ matrix.use_zigbuild && 'cargo zigbuild' || 'cargo build' }} --release
-          --target ${{ matrix.use_zigbuild && matrix.zigbuild_target || matrix.target }}
-          --bin openflows
-          --bin openflows-setup
-          --bin openflows-dashboard
-          --bin openflows-doctor
-          --bin anthropic-proxy
+       - name: Build binaries
+         run: >
+           ${{ matrix.use_zigbuild && 'cargo zigbuild' || 'cargo build' }} --release
+           --target ${{ matrix.use_zigbuild && matrix.zigbuild_target || matrix.target }}
+           --bin openflows
+           --bin openflows-doctor
+           --bin openflows-harness
 
       - name: Create tarball
         run: |
@@ -150,7 +148,7 @@ jobs:
           ARCHIVE="openflows-${VERSION}-${PLATFORM}"
           mkdir -p "dist/${ARCHIVE}"
 
-          for bin in openflows openflows-setup openflows-dashboard openflows-doctor anthropic-proxy; do
+          for bin in openflows openflows-doctor openflows-harness; do
             cp "target/${{ matrix.target }}/release/${bin}" "dist/${ARCHIVE}/"
           done
 


### PR DESCRIPTION
The release workflow was trying to build openflows-setup, openflows-dashboard, and anthropic-proxy, which don't exist in the codebase. This caused every release build to fail with:

```
error: no bin target named `openflows-setup` in default-run packages
```

Update the workflow to only build the three binaries that actually exist:
- openflows
- openflows-doctor  
- openflows-harness

Fixes the v1.1.8 release that failed on the build step.