### PR TITLE
fix(ci): set GH_TOKEN at job level for harness-edge publish step

### DIFF
--- a/.github/workflows/harness-publish.yml
+++ b/.github/workflows/harness-publish.yml
@@ -135,6 +135,8 @@ jobs:
     needs: [resolve-version, build]
     permissions:
       contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -171,8 +173,6 @@ jobs:
           fi
 
       - name: Upload harness tarball to harness-edge
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Fixed asset name — same for every upload. --clobber auto-replaces prior asset.
           ASSET_NAME="openflows-harness-x86_64-unknown-linux-musl.tar.gz"


### PR DESCRIPTION
The `Find or create harness-edge release` step in `publish-edge` was missing `GH_TOKEN`, causing `gh release list` to fail with:
```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
```
Moved `GH_TOKEN: ${{ github.token }}` to job-level `env` so all steps in the job inherit it, and removed the now-redundant step-level `env` from the upload step.