### PR TITLE
fix: scope workflow permissions to job level for zizmor

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -14,9 +14,6 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 concurrency:
   group: release-assets-${{ github.ref }}
   cancel-in-progress: false
@@ -28,6 +25,8 @@ jobs:
   build:
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -51,6 +50,8 @@ jobs:
             use_zigbuild: false
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
@@ -123,6 +124,8 @@ jobs:
     name: Attach assets
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,6 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
@@ -29,6 +26,8 @@ jobs:
   release-plz:
     name: release-plz
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:


### PR DESCRIPTION
Fixes the CI zizmor failure on the release workflows.

- Move `contents: write` off the workflow level onto only the jobs that need it (`release-plz` in release.yml, `attach` in release-assets.yml); the asset `build` job is read-only.
- Set `persist-credentials: false` on the asset build checkout (matches CI convention).

Verified locally with `zizmor .github/workflows` (high severity): no high/error findings remain.