### PR TITLE
feat: run releases only on pushes to main

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -1,9 +1,11 @@
 name: Release Branch Guard
 
-# Enforces the release branching model: the only PRs allowed to target `main`
-# must come from a branch named `release/vX.Y.Z`. `develop` is the integration
-# branch; `main` is release-only and otherwise `develop`/feature branches cannot
-# merge into it.
+# Enforces the release-source model for `main` (the default branch). Only these
+# PR sources may target `main`:
+#   - `develop`          : the integration branch is merged into `main` normally.
+#   - `release-plz-*`    : release-plz's auto-generated version-bump PRs.
+#   - `release/vX.Y.Z`   : (optional) manual release branches.
+# Any other PR to `main` is rejected.
 
 on:
   pull_request:
@@ -20,16 +22,18 @@ permissions:
 
 jobs:
   validate-release-branch:
-    name: Validate release branch
+    name: Validate PR source
     runs-on: ubuntu-latest
     steps:
       - name: Check PR head branch naming
         env:
           HEAD_BRANCH: ${{ github.head_ref }}
         run: |
-          if [[ ! "${HEAD_BRANCH}" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::PRs to 'main' must come from a 'release/vX.Y.Z' branch (got '${HEAD_BRANCH}')."
-            echo "::error::Cut a release branch from 'develop' (e.g. 'release/v1.2.0'), bump versions there, then open the PR to 'main'."
-            exit 1
+          if [[ "${HEAD_BRANCH}" == "develop" ]] \
+            || [[ "${HEAD_BRANCH}" == release-plz-* ]] \
+            || [[ "${HEAD_BRANCH}" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "PR source '${HEAD_BRANCH}' is allowed to target main."
+            exit 0
           fi
-          echo "Release branch '${HEAD_BRANCH}' passes the naming guard."
+          echo "::error::PRs to 'main' must come from 'develop', a 'release-plz-*' branch, or a 'release/vX.Y.Z' branch (got '${HEAD_BRANCH}')."
+          exit 1

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -4,8 +4,9 @@ name: Release Branch Guard
 # PR sources may target `main`:
 #   - `develop`          : the integration branch is merged into `main` normally.
 #   - `release-plz-*`    : release-plz's auto-generated version-bump PRs.
-#   - `release/vX.Y.Z`   : (optional) manual release branches.
-# Any other PR to `main` is rejected.
+# Any other PR to `main` is rejected. Additionally, the PR must originate from
+# this repository (not a fork), so contributors cannot impersonate an allowed
+# source branch name.
 
 on:
   pull_request:
@@ -25,15 +26,24 @@ jobs:
     name: Validate PR source
     runs-on: ubuntu-latest
     steps:
+      - name: Check PR source repository
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          if [[ "${HEAD_REPO}" != "${BASE_REPO}" ]]; then
+            echo "::error::PRs to 'main' must originate from this repository (${BASE_REPO}); got fork '${HEAD_REPO}'. Branch names are not a substitute for source-repository provenance."
+            exit 1
+          fi
+
       - name: Check PR head branch naming
         env:
           HEAD_BRANCH: ${{ github.head_ref }}
         run: |
           if [[ "${HEAD_BRANCH}" == "develop" ]] \
-            || [[ "${HEAD_BRANCH}" == release-plz-* ]] \
-            || [[ "${HEAD_BRANCH}" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            || [[ "${HEAD_BRANCH}" == release-plz-* ]]; then
             echo "PR source '${HEAD_BRANCH}' is allowed to target main."
             exit 0
           fi
-          echo "::error::PRs to 'main' must come from 'develop', a 'release-plz-*' branch, or a 'release/vX.Y.Z' branch (got '${HEAD_BRANCH}')."
+          echo "::error::PRs to 'main' must come from 'develop' or a 'release-plz-*' branch (got '${HEAD_BRANCH}')."
           exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,23 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  gate:
+    name: Enforce main branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check ref
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          if [[ "${REF}" != "refs/heads/main" ]]; then
+            echo "::error::The release workflow must run on 'main'; got '${REF}'. Manual dispatch on another branch would compute release contents from the wrong history."
+            exit 1
+          fi
+
   release-plz:
     name: release-plz (release-pr)
     runs-on: ubuntu-latest
+    needs: gate
     permissions:
       contents: write
       pull-requests: write
@@ -44,7 +58,7 @@ jobs:
   release-plz-release:
     name: release-plz (release)
     runs-on: ubuntu-latest
-    needs: release-plz
+    needs: [gate, release-plz]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,6 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
@@ -31,6 +27,9 @@ jobs:
   release-plz:
     name: release-plz (release-pr)
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -46,6 +45,8 @@ jobs:
     name: release-plz (release)
     runs-on: ubuntu-latest
     needs: release-plz
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,23 +2,26 @@ name: Release
 
 # Auto-releases from Conventional Commits (see release-plz.toml).
 #
-#   - `release-pr`   : runs on pushes to `develop`, scans Conventional
-#                      Commits since the last tag, computes the next version
-#                      (feat→minor, fix→patch, BREAKING CHANGE→major), and opens
-#                      a `release-plz-*` PR that bumps both manifests + CHANGELOG.
-#                      Merge that PR; you never type a version.
-#   - `release`      : runs on pushes to `main`, creates the `vX.Y.Z` tag and the
-#                      GitHub Release. The `release-assets.yml` workflow then
-#                      attaches the cross-platform binary tarballs.
+# Runs ONLY on pushes to `main` (the default branch). Two jobs:
+#   - `release-plz (release-pr)` : scans Conventional Commits since the last tag,
+#     computes the next version (feat→minor, fix→patch, BREAKING CHANGE→major),
+#     and opens a `release-plz-*` PR to `main` bumping both manifests + CHANGELOG.
+#     You merge that PR; you never type a version.
+#   - `release-plz (release)`     : creates the `vX.Y.Z` tag + GitHub Release when
+#     the push is the merge of a `release-plz-*` PR (release_always = false).
+#     The `release-assets.yml` workflow then attaches the cross-platform binaries.
 #
 # Publications to npm / Homebrew / Docker (GHCR) / crates.io are removed.
 
 on:
   push:
     branches:
-      - develop
       - main
   workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
 
 concurrency:
   group: release-${{ github.ref }}
@@ -27,11 +30,7 @@ concurrency:
 jobs:
   release-plz:
     name: release-plz (release-pr)
-    if: github.ref == 'refs/heads/develop' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -45,10 +44,8 @@ jobs:
 
   release-plz-release:
     name: release-plz (release)
-    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    needs: release-plz
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,11 +1,13 @@
 # release-plz configuration.
 #
-# Drives the release workflow (`.github/workflows/release.yml`):
-#   - `release-pr` : on push to `develop`, scans Conventional Commits since the
-#                    last tag, computes the next version, and opens a
-#                    `release-plz-*` PR that bumps both manifests + CHANGELOG.
-#   - `release`    : on push to `main`, creates the single `vX.Y.Z` tag and the
-#                    GitHub Release.
+# Drives the release workflow (`.github/workflows/release.yml`), which runs ONLY
+# on pushes to `main` (the default branch):
+#   - `release-pr` : scans Conventional Commits since the last tag, computes the
+#                    next version, and opens a `release-plz-*` PR to `main` that
+#                    bumps both manifests + CHANGELOG.
+#   - `release`    : creates the single `vX.Y.Z` tag + GitHub Release when the
+#                    main push is the merge of a `release-plz-*` PR
+#                    (`release_always = false`).
 #
 # GitHub integration is via git tags only (`git_only = true`) — the shipped
 # packages are application binaries that are NOT published to crates.io, so
@@ -16,6 +18,9 @@
 git_only = true
 # Explicitly disable crates.io publishing (no CARGO_REGISTRY_TOKEN is provided).
 publish = false
+# Only release when the main push is the merge of a `release-plz-*` release PR
+# (not on every push), avoiding premature tags before the bump PR merges.
+release_always = false
 # Use a single `vX.Y.Z` tag that covers both packages.
 git_tag_name = "v{{ version }}"
 # Only the packages explicitly opted in below are processed. The rest of the


### PR DESCRIPTION
Reorients the release flow so that **release-plz runs only on pushes to `main`** (per discussion), instead of targeting the default `develop` branch.

**Changes**
- `release.yml`: triggers only on `push` to `main` (the eventual default/release branch). Runs both `release-plz` (`release-pr`) and `release-plz-release` (`release`) jobs there.
- `release-plz.toml`: sets `release_always = false` so `release` fires only when the main push is the merge of a `release-plz-*` PR — no premature tags before the bump PR merges.
- `release-branch.yml`: guard now permits PRs to `main` from `develop`, `release-plz-*`, and `release/vX.Y.Z`.

**Note:** This is part of the broader move to `main`-as-default. The GitHub default-branch switch (`develop` → `main`) and re-pointing CI/semver + branch protection are follow-up steps not included in this PR.