### PR TITLE
feat: split releases into openflows and openflows-harness without v prefix

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -1,17 +1,22 @@
 name: Release Assets
 
-# Builds the cross-platform binary tarballs for a release and attaches them to
-# the GitHub Release that release-plz created (see `release.yml`).
+# Builds and attaches the cross-platform binary tarballs to the two per-package
+# GitHub Releases that release-plz created (see `release.yml`).
 #
-# This workflow is triggered by the `v*` tag push that release-plz produces when
-# a release branch is merged to `main`. Asset names are predictable/fixed so
-# re-runs overwrite (never error): `openflows-<tag>-<target>.tar.gz(+.sha256)`
-# plus a standalone `openflows-harness-x86_64-unknown-linux-musl.tar.gz`.
+# Each of the two released packages gets its OWN super-tag/release:
+#   - `openflows-<version>`        -> release "openflows"        -> asset `openflows-<version>-<target>.tar.gz`
+#   - `openflows-harness-<version>` -> release "openflows-harness" -> asset `openflows-harness-<version>-<target>.tar.gz`
+#
+# Tag names carry no `v` prefix. The package owning the tag is derived from the
+# tag name (`openflows-` vs `openflows-harness-`), and each run only builds and
+# attaches that package's own binaries. Asset names are predictable/fixed so
+# re-runs overwrite (never error).
 
 on:
   push:
     tags:
-      - 'v[0-9]*.[0-9]*.[0-9]*'
+      - 'openflows-[0-9]*.[0-9]*.[0-9]*'
+      - 'openflows-harness-[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
 
 concurrency:
@@ -61,6 +66,20 @@ jobs:
         with:
           target: ${{ matrix.target }}
 
+      - name: Resolve package from tag
+        id: pkg
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "${REF_NAME}" == openflows-harness-* ]]; then
+            echo "name=openflows-harness" >> "$GITHUB_OUTPUT"
+          elif [[ "${REF_NAME}" == openflows-* ]]; then
+            echo "name=openflows" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Unexpected release tag '${REF_NAME}'"
+            exit 1
+          fi
+
       - name: Install build dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -103,43 +122,43 @@ jobs:
           tool: cargo-zigbuild@0.23.0
 
       - name: Build binaries
-        run: >
-          ${{ matrix.use_zigbuild && 'cargo zigbuild' || 'cargo build' }} --release
-          --target ${{ matrix.use_zigbuild && matrix.zigbuild_target || matrix.target }}
-          --bin openflows
-          --bin openflows-doctor
-          --bin openflows-harness
+        env:
+          PACKAGE: ${{ steps.pkg.outputs.name }}
+        run: |
+          PLATFORM_TARGET="${{ matrix.use_zigbuild && matrix.zigbuild_target || matrix.target }}"
+          if [[ "${PACKAGE}" == "openflows-harness" ]]; then
+            ${{ matrix.use_zigbuild && 'cargo zigbuild' || 'cargo build' }} --release \
+              --target "${PLATFORM_TARGET}" --bin openflows-harness
+          else
+            ${{ matrix.use_zigbuild && 'cargo zigbuild' || 'cargo build' }} --release \
+              --target "${PLATFORM_TARGET}" --bin openflows --bin openflows-doctor
+          fi
 
       - name: Create tarball
+        env:
+          PACKAGE: ${{ steps.pkg.outputs.name }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          set -euo pipefail
+          PKG="${PACKAGE}"
+          VERSION="${REF_NAME#${PKG}-}"
           PLATFORM="${{ matrix.target }}"
-          ARCHIVE="openflows-${VERSION}-${PLATFORM}"
+          ARCHIVE="${PKG}-${VERSION}-${PLATFORM}"
           mkdir -p "dist/${ARCHIVE}"
 
-          for bin in openflows openflows-doctor openflows-harness; do
-            cp "target/${{ matrix.target }}/release/${bin}" "dist/${ARCHIVE}/"
-          done
-
-          cp -r orchestration "dist/${ARCHIVE}/"
-          cp README.md LICENSE "dist/${ARCHIVE}/" 2>/dev/null || true
+          if [[ "${PKG}" == "openflows-harness" ]]; then
+            cp "target/${{ matrix.target }}/release/openflows-harness" "dist/${ARCHIVE}/"
+          else
+            for bin in openflows openflows-doctor; do
+              cp "target/${{ matrix.target }}/release/${bin}" "dist/${ARCHIVE}/"
+            done
+            cp -r orchestration "dist/${ARCHIVE}/"
+            cp README.md LICENSE "dist/${ARCHIVE}/" 2>/dev/null || true
+          fi
 
           tar -czf "dist/${ARCHIVE}.tar.gz" -C dist "${ARCHIVE}"
           cd dist
           sha256sum "${ARCHIVE}.tar.gz" > "${ARCHIVE}.tar.gz.sha256"
-
-      # Standalone harness tarball with a fixed, predictable asset name so every
-      # upload to the release overwrites the previous one (matches the install
-      # URL convention and the historical harness asset naming).
-      - name: Copy standalone harness (linux-musl only)
-        if: matrix.target == 'x86_64-unknown-linux-musl'
-        run: |
-          mkdir -p "dist/_harness_tmp"
-          cp "target/${{ matrix.target }}/release/openflows-harness" "dist/_harness_tmp/"
-          chmod +x "dist/_harness_tmp/openflows-harness"
-          tar -czf "dist/openflows-harness-x86_64-unknown-linux-musl.tar.gz" \
-            -C dist "_harness_tmp/openflows-harness"
-          rm -rf "dist/_harness_tmp"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,13 @@ name: Release
 # Runs ONLY on pushes to `main` (the default branch). Two jobs:
 #   - `release-plz (release-pr)` : scans Conventional Commits since the last tag,
 #     computes the next version (feat→minor, fix→patch, BREAKING CHANGE→major),
-#     and opens a `release-plz-*` PR to `main` bumping both manifests + CHANGELOG.
+#     and opens a `release-plz-*` PR to `main` bumping the manifests + CHANGELOG.
 #     You merge that PR; you never type a version.
-#   - `release-plz (release)`     : creates the `vX.Y.Z` tag + GitHub Release when
-#     the push is the merge of a `release-plz-*` PR (release_always = false).
-#     The `release-assets.yml` workflow then attaches the cross-platform binaries.
+#   - `release-plz (release)`     : when the push is the merge of a `release-plz-*`
+#     PR (release_always = false), creates ONE tag + GitHub Release per released
+#     binary: `openflows-<version>` and `openflows-harness-<version>` (no `v`
+#     prefix). The `release-assets.yml` workflow then attaches the cross-platform
+#     binaries to each package's own release.
 #
 # Publications to npm / Homebrew / Docker (GHCR) / crates.io are removed.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,8 +17,10 @@ develop ──┐
           └─(create)──▶ release/vX.Y.Z ──PR merge──▶ main
                                                     │  push to main
                                                     ▼
-                          release-plz release → tag vX.Y.Z + GitHub Release
-                          release-assets → attach cross-platform tarballs
+                          release-plz release → tag openflows-X.Y.Z
+                                              + tag openflows-harness-X.Y.Z
+                                              (one GitHub Release per binary, no `v`)
+                          release-assets → attach each binary's tarballs to its own release
 ```
 
 - `develop` is the default branch and the integration point. All feature work
@@ -39,9 +41,9 @@ Conventional Commits merged since the last tag:
 | `feat:`                          | **minor**    |
 | `fix:`, `docs:`, `chore:`, …     | **patch**    |
 
-`release-plz` opens a `release-plz-*` pull request to `develop` that bumps both
-manifest versions in lock-step and regenerates the CHANGELOG. Merging that PR
-"locks in" the new version.
+`release-plz` opens a `release-plz-*` pull request to `develop` that bumps each
+released package's manifest version and regenerates the CHANGELOG. Merging that
+PR "locks in" the new version.
 
 > The very first release (no tags yet in the repo — the old tag history was
 > deleted for a clean start) is treated as an **initial release** and ships at
@@ -80,13 +82,21 @@ manifest versions in lock-step and regenerates the CHANGELOG. Merging that PR
    - The release happens on merge.
 
 5. Merge the PR into `main`. On push to `main`, **release-plz `release`** creates
-   the `vX.Y.Z` tag and the GitHub Release.
+   one tag and GitHub Release per binary:
 
-6. The tag push triggers **release-assets**, which builds and attaches:
+   - `openflows-X.Y.Z` (release **openflows**),
+   - `openflows-harness-X.Y.Z` (release **openflows-harness**).
 
-   - `openflows-<v>-<target>.tar.gz` + `.sha256` for
-     x86_64/aarch64 Linux-GNU (zigbuild), Linux-musl, and macOS,
-   - a standalone `openflows-harness-x86_64-unknown-linux-musl.tar.gz`.
+   Tag/release names carry no `v` prefix.
+
+6. Each tag push triggers **release-assets**, which builds and attaches that
+   package's own cross-platform tarballs:
+
+   - on `openflows-*` tags: `openflows-<X.Y.Z>-<target>.tar.gz` + `.sha256`
+     for x86_64/aarch64 Linux-GNU (zigbuild), Linux-musl, and macOS, containing
+     the `openflows` and `openflows-doctor` binaries plus `orchestration/`;
+   - on `openflows-harness-*` tags: `openflows-harness-<X.Y.Z>-<target>.tar.gz`
+     + `.sha256` containing the `openflows-harness` binary.
 
    Asset names are fixed/predictable, so re-runs overwrite rather than error.
 
@@ -100,7 +110,9 @@ enforces this on every PR.
 
 ## Notes
 
-- Version lock-step: `openflows` and `openflows-harness` are grouped in
-  `release-plz.toml` via `version_group`, so one tag/version covers both.
+- Independent releases: `openflows` and `openflows-harness` are released
+  separately in `release-plz.toml`, each with its own tag
+  (`openflows-X.Y.Z` / `openflows-harness-X.Y.Z`) and GitHub Release, so they can
+  ship independently. The installer fetches both releases at the same version.
 - No crates.io publishing is configured (these are application binaries);
   `release-plz.toml` uses `git_only = true` and `publish = false`.

--- a/binary/Cargo.toml
+++ b/binary/Cargo.toml
@@ -16,16 +16,16 @@ name = "openflows-doctor"
 path = "src/bin/doctor.rs"
 
 [dependencies]
-pocketflow-core = { path = "../crates/pocketflow-core" }
-config          = { path = "../crates/config" }
-agent-nexus     = { path = "../crates/agent-nexus" }
-agent-forge     = { path = "../crates/agent-forge" }
-agent-vessel    = { path = "../crates/agent-vessel" }
-agent-sentinel  = { path = "../crates/agent-sentinel" }
-agent-lore      = { path = "../crates/agent-lore" }
-provisioner    = { path = "../crates/provisioner" }
-coder-client    = { path = "../crates/coder-client" }
-openflows-harness = { path = "../crates/openflows-harness" }
+pocketflow-core = { version = "0.1.0", path = "../crates/pocketflow-core" }
+config          = { version = "0.2.0", path = "../crates/config" }
+agent-nexus     = { version = "0.1.0", path = "../crates/agent-nexus" }
+agent-forge     = { version = "0.1.0", path = "../crates/agent-forge" }
+agent-vessel    = { version = "0.1.0", path = "../crates/agent-vessel" }
+agent-sentinel  = { version = "1.1.6", path = "../crates/agent-sentinel" }
+agent-lore      = { version = "0.1.0", path = "../crates/agent-lore" }
+provisioner    = { version = "0.1.0", path = "../crates/provisioner" }
+coder-client    = { version = "0.1.0", path = "../crates/coder-client" }
+openflows-harness = { version = "1.2.0", path = "../crates/openflows-harness" }
 clap            = { version = "4", features = ["derive"] }
 
   anyhow      = { workspace = true }

--- a/crates/agent-forge/Cargo.toml
+++ b/crates/agent-forge/Cargo.toml
@@ -8,9 +8,9 @@ license = "MIT"
 ignored = ["serde", "tokio"]
 
 [dependencies]
-pocketflow-core = { path = "../pocketflow-core" }
-config = { path = "../config" }
-coder-client = { path = "../coder-client", features = ["chats-api"] }
+pocketflow-core = { version = "0.1.0", path = "../pocketflow-core" }
+config = { version = "0.2.0", path = "../config" }
+coder-client = { version = "0.1.0", path = "../coder-client", features = ["chats-api"] }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/agent-lore/Cargo.toml
+++ b/crates/agent-lore/Cargo.toml
@@ -12,6 +12,6 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 chrono = "0.4"
-pocketflow-core = { path = "../pocketflow-core" }
-config = { path = "../config" }
-github = { path = "../github" }
+pocketflow-core = { version = "0.1.0", path = "../pocketflow-core" }
+config = { version = "0.2.0", path = "../config" }
+github = { version = "0.1.0", path = "../github" }

--- a/crates/agent-nexus/Cargo.toml
+++ b/crates/agent-nexus/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-pocketflow-core = { path = "../pocketflow-core" }
-config = { path = "../config" }
-github = { path = "../github" }
-coder-client = { path = "../coder-client" }
-openflows-notifier = { package = "notifier", path = "../notifier" }
-a2a-protocol = { path = "../a2a-protocol" }
-provisioner = { path = "../provisioner" }
+pocketflow-core = { version = "0.1.0", path = "../pocketflow-core" }
+config = { version = "0.2.0", path = "../config" }
+github = { version = "0.1.0", path = "../github" }
+coder-client = { version = "0.1.0", path = "../coder-client" }
+openflows-notifier = { package = "notifier", version = "0.1.0", path = "../notifier" }
+a2a-protocol = { version = "0.1.0", path = "../a2a-protocol" }
+provisioner = { version = "0.1.0", path = "../provisioner" }
 
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/crates/agent-sentinel/Cargo.toml
+++ b/crates/agent-sentinel/Cargo.toml
@@ -7,9 +7,9 @@ license = "MIT"
 [package.metadata.cargo-machete]
 ignored = ["tokio"]
 [dependencies]
-pocketflow-core = { path = "../pocketflow-core" }
-config          = { path = "../config" }
-coder-client    = { path = "../coder-client", features = ["chats-api"] }
+pocketflow-core = { version = "0.1.0", path = "../pocketflow-core" }
+config          = { version = "0.2.0", path = "../config" }
+coder-client    = { version = "0.1.0", path = "../coder-client", features = ["chats-api"] }
   anyhow      = { workspace = true }
   async-trait = { workspace = true }
   serde       = { workspace = true }

--- a/crates/agent-vessel/Cargo.toml
+++ b/crates/agent-vessel/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-pocketflow-core = { path = "../pocketflow-core" }
-config = { path = "../config" }
-github = { path = "../github" }
-provisioner = { path = "../provisioner" }
-coder-client = { path = "../coder-client" }
-openflows-notifier = { package = "notifier", path = "../notifier" }
+pocketflow-core = { version = "0.1.0", path = "../pocketflow-core" }
+config = { version = "0.2.0", path = "../config" }
+github = { version = "0.1.0", path = "../github" }
+provisioner = { version = "0.1.0", path = "../provisioner" }
+coder-client = { version = "0.1.0", path = "../coder-client" }
+openflows-notifier = { package = "notifier", version = "0.1.0", path = "../notifier" }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/github/Cargo.toml
+++ b/crates/github/Cargo.toml
@@ -13,4 +13,4 @@ tracing       = { workspace = true }
 reqwest       = { workspace = true }
 regex         = "1"
 rand          = { workspace = true }
-pocketflow-core = { path = "../pocketflow-core" }
+pocketflow-core = { version = "0.1.0", path = "../pocketflow-core" }

--- a/crates/openflows-harness/Cargo.toml
+++ b/crates/openflows-harness/Cargo.toml
@@ -13,8 +13,8 @@ name = "openflows-harness"
 path = "src/main.rs"
 
 [dependencies]
-a2a-protocol = { path = "../a2a-protocol" }
-config = { path = "../config" }
+a2a-protocol = { version = "0.1.0", path = "../a2a-protocol" }
+config = { version = "0.2.0", path = "../config" }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/provisioner/Cargo.toml
+++ b/crates/provisioner/Cargo.toml
@@ -15,8 +15,8 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 async-trait = { workspace = true }
-config = { path = "../config" }
-coder-client = { path = "../coder-client" }
+config = { version = "0.2.0", path = "../config" }
+coder-client = { version = "0.1.0", path = "../coder-client" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,14 +4,19 @@
 # on pushes to `main` (the default branch):
 #   - `release-pr` : scans Conventional Commits since the last tag, computes the
 #                    next version, and opens a `release-plz-*` PR to `main` that
-#                    bumps both manifests + CHANGELOG.
-#   - `release`    : creates the single `vX.Y.Z` tag + GitHub Release when the
-#                    main push is the merge of a `release-plz-*` PR
+#                    bumps the manifest + CHANGELOG.
+#   - `release`    : creates the per-package tag + GitHub Release when the main
+#                    push is the merge of a `release-plz-*` PR
 #                    (`release_always = false`).
 #
 # GitHub integration is via git tags only (`git_only = true`) — the shipped
 # packages are application binaries that are NOT published to crates.io, so
 # release-plz never runs `cargo publish` and never queries the registry.
+#
+# Each shipped binary gets its OWN github release + git tag. Tag names carry no
+# `v` prefix and are namespaced per package so the two binaries can be released
+# independently at the same version without colliding (`openflows-1.2.0` vs
+# `openflows-harness-1.2.0`).
 
 [workspace]
 # Determine released versions from git tags instead of the crates.io registry.
@@ -21,21 +26,20 @@ publish = false
 # Only release when the main push is the merge of a `release-plz-*` release PR
 # (not on every push), avoiding premature tags before the bump PR merges.
 release_always = false
-# Use a single `vX.Y.Z` tag that covers both packages.
-git_tag_name = "v{{ version }}"
 # Only the packages explicitly opted in below are processed. The rest of the
 # workspace crates are libraries/sub-crates and are intentionally not released.
 release = false
 
-# `openflows` and `openflows-harness` are kept in lock-step so that one tag and
-# one GitHub Release cover both binaries. `version_group` forces both packages
-# to share the same version.
+# `openflows` and `openflows-harness` are released independently: one git tag
+# and one GitHub Release per binary. The per-package `git_tag_name` avoids a
+# tag collision when both are at the same version, and omits the `v` prefix.
+
 [[package]]
 name = "openflows"
 release = true
-version_group = "openflows"
+git_tag_name = "openflows-{{ version }}"
 
 [[package]]
 name = "openflows-harness"
 release = true
-version_group = "openflows"
+git_tag_name = "openflows-harness-{{ version }}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -177,67 +177,79 @@ install_orchestration() {
     fi
 }
 
-download_binary() {
-    local platform="$1"
-    local tag="$2"
-    local asset_name="openflows-${tag}-${platform}.tar.gz"
+# Download a single release tarball into /tmp, trying the musl fallback for
+# platforms without a native binary.
+download_one() {
+    local pkg="$1"
+    local version="$2"
+    local platform="$3"
+    local out_var="$4"          # name of the var to set with the downloaded archive
+    local asset_name="${pkg}-${version}-${platform}.tar.gz"
+    local url="https://github.com/${REPO}/releases/download/${pkg}-${version}/${asset_name}"
+    local downloaded=""
 
-    info "Downloading OpenFlows ${tag} for ${platform}..."
-
-    local download_url="https://github.com/${REPO}/releases/download/${tag}/${asset_name}"
-
-    local download_ok=false
     if has_cmd curl; then
-        if curl -fsSL "$download_url" -o "/tmp/${asset_name}" 2>/dev/null; then
-            download_ok=true
+        if curl -fsSL "$url" -o "/tmp/${asset_name}" 2>/dev/null; then
+            downloaded="$asset_name"
         fi
     elif has_cmd wget; then
-        if wget -q "$download_url" -O "/tmp/${asset_name}" 2>/dev/null; then
-            download_ok=true
+        if wget -q "$url" -O "/tmp/${asset_name}" 2>/dev/null; then
+            downloaded="$asset_name"
         fi
     else
         fail "Neither curl nor wget found"
         return 1
     fi
 
-    if [ "$download_ok" = false ]; then
+    if [ -z "$downloaded" ]; then
         local alt_platform=""
         case "$platform" in
             x86_64-unknown-linux-gnu)  alt_platform="x86_64-unknown-linux-musl" ;;
             aarch64-unknown-linux-gnu) alt_platform="aarch64-unknown-linux-musl" ;;
             *) ;;
         esac
-
         if [ -n "$alt_platform" ]; then
-            local alt_asset="openflows-${tag}-${alt_platform}.tar.gz"
-            local alt_url="https://github.com/${REPO}/releases/download/${tag}/${alt_asset}"
-            warn "No binary for ${platform}, trying ${alt_platform}..."
-            if has_cmd curl; then
-                if curl -fsSL "$alt_url" -o "/tmp/${alt_asset}" 2>/dev/null; then
-                    download_ok=true
-                    asset_name="$alt_asset"
-                    platform="$alt_platform"
-                fi
-            elif has_cmd wget; then
-                if wget -q "$alt_url" -O "/tmp/${alt_asset}" 2>/dev/null; then
-                    download_ok=true
-                    asset_name="$alt_asset"
-                    platform="$alt_platform"
-                fi
+            local alt_asset="${pkg}-${version}-${alt_platform}.tar.gz"
+            local alt_url="https://github.com/${REPO}/releases/download/${pkg}-${version}/${alt_asset}"
+            warn "No ${pkg} binary for ${platform}, trying ${alt_platform}..."
+            if has_cmd curl && curl -fsSL "$alt_url" -o "/tmp/${alt_asset}" 2>/dev/null; then
+                downloaded="$alt_asset"
+            elif has_cmd wget && wget -q "$alt_url" -O "/tmp/${alt_asset}" 2>/dev/null; then
+                downloaded="$alt_asset"
             fi
-        fi
-
-        if [ "$download_ok" = false ]; then
-            fail "Failed to download binary for ${platform}"
-            info "Falling back to building from source..."
-            return 1
         fi
     fi
 
-    tar -xzf "/tmp/${asset_name}" -C /tmp/
-    rm -f "/tmp/${asset_name}"
+    if [ -z "$downloaded" ]; then
+        return 1
+    fi
 
-    local extract_dir="/tmp/openflows-${tag}-${platform}"
+    printf -v "$out_var" "%s" "$downloaded"
+    tar -xzf "/tmp/${downloaded}" -C /tmp/
+    rm -f "/tmp/${downloaded}"
+    return 0
+}
+
+download_binary() {
+    local platform="$1"
+    local version="$2"
+
+    info "Downloading OpenFlows ${version} for ${platform}..."
+
+    local main_archive=""
+    local harness_archive=""
+    if ! download_one "openflows" "$version" "$platform" main_archive; then
+        fail "Failed to download openflows binary for ${platform}"
+        info "Falling back to building from source..."
+        return 1
+    fi
+
+    # The harness ships in its own release; download it too, but don't fail the
+    # whole install if a particular platform has no harness build.
+    download_one "openflows-harness" "$version" "$platform" harness_archive \
+        || warn "No openflows-harness binary for ${platform}; skipping harness"
+
+    local extract_dir="/tmp/openflows-${version}-${platform}"
     for bin in "${BINARIES[@]}"; do
         if [ -f "${extract_dir}/${bin}" ]; then
             cp "${extract_dir}/${bin}" "${INSTALL_DIR}/"
@@ -280,30 +292,33 @@ build_from_source() {
 }
 
 resolve_stable_tag() {
+    # Resolve the version (without prefix) of the latest stable `openflows-*`
+    # release. `openflows` is the main release; harness shares its version.
     local tag=""
     if has_cmd gh; then
-        tag=$(gh release view --repo "$REPO" --json tagName -q .tagName 2>/dev/null || echo "")
+        tag=$(gh release list --repo "$REPO" --limit 100 --json tagName,isPrerelease \
+            -q '[.[] | select(.tagName | startswith("openflows-"))] | map(select(.isPrerelease == false)) | .[0].tagName' 2>/dev/null || echo "")
     fi
     if [ -z "$tag" ]; then
-        tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null \
-            | grep '"tag_name"' | head -1 \
-            | sed 's/.*"tag_name": "//;s/".*//' || echo "")
+        tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>/dev/null \
+            | jq -r '[.[] | select(.prerelease == false) | select(.tag_name | startswith("openflows-"))] | .[0].tag_name' 2>/dev/null || echo "")
     fi
-    echo "$tag"
+    echo "${tag#openflows-}"
 }
 
 resolve_edge_tag() {
+    # Resolve the version (without prefix) of the latest pre-release
+    # `openflows-*` build from main.
     local tag=""
     if has_cmd gh; then
-        tag=$(gh release list --repo "$REPO" --limit 50 --json tagName,isPrerelease \
-            -q '.[] | select(.isPrerelease == true) | .tagName' 2>/dev/null \
-            | head -1 || echo "")
+        tag=$(gh release list --repo "$REPO" --limit 100 --json tagName,isPrerelease \
+            -q '[.[] | select(.tagName | startswith("openflows-"))] | map(select(.isPrerelease == true)) | .[0].tagName' 2>/dev/null || echo "")
     fi
     if [ -z "$tag" ]; then
-        tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=50" 2>/dev/null \
-            | jq -r '[.[] | select(.prerelease == true)] | .[0].tag_name' 2>/dev/null || echo "")
+        tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>/dev/null \
+            | jq -r '[.[] | select(.prerelease == true) | select(.tag_name | startswith("openflows-"))] | .[0].tag_name' 2>/dev/null || echo "")
     fi
-    echo "$tag"
+    echo "${tag#openflows-}"
 }
 
 ensure_path() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -232,30 +232,48 @@ download_one() {
 
 download_binary() {
     local platform="$1"
-    local version="$2"
+    local main_version="$2"
+    local harness_version="${3:-$main_version}"
 
-    info "Downloading OpenFlows ${version} for ${platform}..."
+    info "Downloading OpenFlows ${main_version} for ${platform}..."
 
     local main_archive=""
     local harness_archive=""
-    if ! download_one "openflows" "$version" "$platform" main_archive; then
+    if ! download_one "openflows" "$main_version" "$platform" main_archive; then
         fail "Failed to download openflows binary for ${platform}"
         info "Falling back to building from source..."
         return 1
     fi
 
-    # The harness ships in its own release; download it too, but don't fail the
-    # whole install if a particular platform has no harness build.
-    download_one "openflows-harness" "$version" "$platform" harness_archive \
-        || warn "No openflows-harness binary for ${platform}; skipping harness"
+    # The harness ships in its own release, possibly at its own version;
+    # download it too, but don't fail the whole install if a particular
+    # platform has no harness build.
+    local harness_copied=false
+    if download_one "openflows-harness" "$harness_version" "$platform" harness_archive; then
+        harness_copied=true
+    else
+        warn "No openflows-harness binary for ${platform}; skipping harness"
+    fi
 
-    local extract_dir="/tmp/openflows-${version}-${platform}"
+    local extract_dir="/tmp/openflows-${main_version}-${platform}"
     for bin in "${BINARIES[@]}"; do
         if [ -f "${extract_dir}/${bin}" ]; then
             cp "${extract_dir}/${bin}" "${INSTALL_DIR}/"
             chmod +x "${INSTALL_DIR}/${bin}"
         fi
     done
+
+    # The harness archive extracts to its own package-named directory, so copy
+    # it separately rather than searching the main package's directory.
+    if [ "$harness_copied" = true ]; then
+        local harness_dir="/tmp/openflows-harness-${harness_version}-${platform}"
+        if [ -f "${harness_dir}/openflows-harness" ]; then
+            cp "${harness_dir}/openflows-harness" "${INSTALL_DIR}/"
+            chmod +x "${INSTALL_DIR}/openflows-harness"
+            success "Installed openflows-harness"
+        fi
+        rm -rf "${harness_dir}"
+    fi
 
     if [ -d "${extract_dir}/orchestration" ]; then
         install_orchestration "${extract_dir}"
@@ -291,34 +309,44 @@ build_from_source() {
     fi
 }
 
-resolve_stable_tag() {
-    # Resolve the version (without prefix) of the latest stable `openflows-*`
-    # release. `openflows` is the main release; harness shares its version.
+# Resolve the version (without prefix) of the latest release for a package.
+#
+# `tag_prefix` must be the exact tag prefix for that package: `openflows-` for
+# the main release and `openflows-harness-` for the harness. `openflows-harness-`
+# tags share the `openflows-` prefix with the main package's tags, so `exclude_prefix`
+# (e.g. `openflows-harness-` when resolving the main release) stops a newer harness
+# tag from being mistaken for the main package. Each package is resolved
+# independently so the two can be released at their own versions.
+#
+# `prerelease` selects the channel: "false" for stable, "true" for edge.
+resolve_tag() {
+    local tag_prefix="$1"
+    local prerelease="$2"
+    local exclude_prefix="${3:-}"
     local tag=""
     if has_cmd gh; then
-        tag=$(gh release list --repo "$REPO" --limit 100 --json tagName,isPrerelease \
-            -q '[.[] | select(.tagName | startswith("openflows-"))] | map(select(.isPrerelease == false)) | .[0].tagName' 2>/dev/null || echo "")
+        if [ -n "$exclude_prefix" ]; then
+            tag=$(gh release list --repo "$REPO" --limit 100 --json tagName,isPrerelease \
+                -q --arg pfx "$tag_prefix" --arg ex "$exclude_prefix" --arg pre "$prerelease" \
+                '[.[] | select(.tagName | startswith($pfx)) | select((.tagName | startswith($ex)) | not)] | map(select((.isPrerelease | tostring) == $pre)) | .[0].tagName' 2>/dev/null || echo "")
+        else
+            tag=$(gh release list --repo "$REPO" --limit 100 --json tagName,isPrerelease \
+                -q --arg pfx "$tag_prefix" --arg pre "$prerelease" \
+                '[.[] | select(.tagName | startswith($pfx))] | map(select((.isPrerelease | tostring) == $pre)) | .[0].tagName' 2>/dev/null || echo "")
+        fi
     fi
     if [ -z "$tag" ]; then
-        tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>/dev/null \
-            | jq -r '[.[] | select(.prerelease == false) | select(.tag_name | startswith("openflows-"))] | .[0].tag_name' 2>/dev/null || echo "")
+        if [ -n "$exclude_prefix" ]; then
+            tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>/dev/null \
+                | jq -r --arg pfx "$tag_prefix" --arg ex "$exclude_prefix" --arg pre "$prerelease" \
+                '[.[] | select((.prerelease | tostring) == $pre) | select(.tag_name | startswith($pfx)) | select((.tag_name | startswith($ex)) | not)] | .[0].tag_name' 2>/dev/null || echo "")
+        else
+            tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>/dev/null \
+                | jq -r --arg pfx "$tag_prefix" --arg pre "$prerelease" \
+                '[.[] | select((.prerelease | tostring) == $pre) | select(.tag_name | startswith($pfx))] | .[0].tag_name' 2>/dev/null || echo "")
+        fi
     fi
-    echo "${tag#openflows-}"
-}
-
-resolve_edge_tag() {
-    # Resolve the version (without prefix) of the latest pre-release
-    # `openflows-*` build from main.
-    local tag=""
-    if has_cmd gh; then
-        tag=$(gh release list --repo "$REPO" --limit 100 --json tagName,isPrerelease \
-            -q '[.[] | select(.tagName | startswith("openflows-"))] | map(select(.isPrerelease == true)) | .[0].tagName' 2>/dev/null || echo "")
-    fi
-    if [ -z "$tag" ]; then
-        tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>/dev/null \
-            | jq -r '[.[] | select(.prerelease == true) | select(.tag_name | startswith("openflows-"))] | .[0].tag_name' 2>/dev/null || echo "")
-    fi
-    echo "${tag#openflows-}"
+    echo "${tag#${tag_prefix}}"
 }
 
 ensure_path() {
@@ -389,19 +417,23 @@ main() {
     local tag=""
 
     if [ "$CHANNEL" = "edge" ]; then
-        tag=$(resolve_edge_tag)
+        tag=$(resolve_tag "openflows-" "true" "openflows-harness-")
+        local harness_tag
+        harness_tag=$(resolve_tag "openflows-harness-" "true")
         if [ -n "$tag" ]; then
             info "Found edge release: $tag"
-            if download_binary "$platform" "$tag"; then
+            if download_binary "$platform" "$tag" "$harness_tag"; then
                 installed=true
             fi
         else
             warn "No edge release found. Falling back to building from latest main..."
         fi
     else
-        tag=$(resolve_stable_tag)
+        tag=$(resolve_tag "openflows-" "false" "openflows-harness-")
+        local harness_tag
+        harness_tag=$(resolve_tag "openflows-harness-" "false")
         if [ -n "$tag" ]; then
-            if download_binary "$platform" "$tag"; then
+            if download_binary "$platform" "$tag" "$harness_tag"; then
                 installed=true
             fi
         fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -178,15 +178,18 @@ install_orchestration() {
 }
 
 # Download a single release tarball into /tmp, trying the musl fallback for
-# platforms without a native binary.
+# platforms without a native binary. `out_var` receives the extraction
+# directory name (which reflects the platform actually downloaded, e.g. the
+# musl fallback) so the caller knows where the unpacked files live.
 download_one() {
     local pkg="$1"
     local version="$2"
     local platform="$3"
-    local out_var="$4"          # name of the var to set with the downloaded archive
+    local out_var="$4"          # var to set with the extraction directory name
     local asset_name="${pkg}-${version}-${platform}.tar.gz"
     local url="https://github.com/${REPO}/releases/download/${pkg}-${version}/${asset_name}"
     local downloaded=""
+    local resolved_platform="$platform"
 
     if has_cmd curl; then
         if curl -fsSL "$url" -o "/tmp/${asset_name}" 2>/dev/null; then
@@ -214,8 +217,10 @@ download_one() {
             warn "No ${pkg} binary for ${platform}, trying ${alt_platform}..."
             if has_cmd curl && curl -fsSL "$alt_url" -o "/tmp/${alt_asset}" 2>/dev/null; then
                 downloaded="$alt_asset"
+                resolved_platform="$alt_platform"
             elif has_cmd wget && wget -q "$alt_url" -O "/tmp/${alt_asset}" 2>/dev/null; then
                 downloaded="$alt_asset"
+                resolved_platform="$alt_platform"
             fi
         fi
     fi
@@ -224,9 +229,9 @@ download_one() {
         return 1
     fi
 
-    printf -v "$out_var" "%s" "$downloaded"
     tar -xzf "/tmp/${downloaded}" -C /tmp/
     rm -f "/tmp/${downloaded}"
+    printf -v "$out_var" "%s" "${pkg}-${version}-${resolved_platform}"
     return 0
 }
 
@@ -237,9 +242,8 @@ download_binary() {
 
     info "Downloading OpenFlows ${main_version} for ${platform}..."
 
-    local main_archive=""
-    local harness_archive=""
-    if ! download_one "openflows" "$main_version" "$platform" main_archive; then
+    local main_dir=""
+    if ! download_one "openflows" "$main_version" "$platform" main_dir; then
         fail "Failed to download openflows binary for ${platform}"
         info "Falling back to building from source..."
         return 1
@@ -248,14 +252,15 @@ download_binary() {
     # The harness ships in its own release, possibly at its own version;
     # download it too, but don't fail the whole install if a particular
     # platform has no harness build.
+    local harness_dir=""
     local harness_copied=false
-    if download_one "openflows-harness" "$harness_version" "$platform" harness_archive; then
+    if download_one "openflows-harness" "$harness_version" "$platform" harness_dir; then
         harness_copied=true
     else
         warn "No openflows-harness binary for ${platform}; skipping harness"
     fi
 
-    local extract_dir="/tmp/openflows-${main_version}-${platform}"
+    local extract_dir="/tmp/${main_dir}"
     for bin in "${BINARIES[@]}"; do
         if [ -f "${extract_dir}/${bin}" ]; then
             cp "${extract_dir}/${bin}" "${INSTALL_DIR}/"
@@ -266,13 +271,12 @@ download_binary() {
     # The harness archive extracts to its own package-named directory, so copy
     # it separately rather than searching the main package's directory.
     if [ "$harness_copied" = true ]; then
-        local harness_dir="/tmp/openflows-harness-${harness_version}-${platform}"
-        if [ -f "${harness_dir}/openflows-harness" ]; then
-            cp "${harness_dir}/openflows-harness" "${INSTALL_DIR}/"
+        if [ -f "/tmp/${harness_dir}/openflows-harness" ]; then
+            cp "/tmp/${harness_dir}/openflows-harness" "${INSTALL_DIR}/"
             chmod +x "${INSTALL_DIR}/openflows-harness"
             success "Installed openflows-harness"
         fi
-        rm -rf "${harness_dir}"
+        rm -rf "/tmp/${harness_dir}"
     fi
 
     if [ -d "${extract_dir}/orchestration" ]; then
@@ -309,6 +313,28 @@ build_from_source() {
     fi
 }
 
+# Build a jq filter for `gh release list -q` matching the exact tag prefix,
+# optionally excluding a longer prefix, and selecting only the requested
+# channel. The values are inlined as `__PFX__`/`__EX__`/`__PRE__` placeholders
+# (safe characters only) and substituted below, so no `--arg` bindings are
+# passed to gh — gh's `-q` accepts only the jq expression. gh runs its own
+# embedded jq, so no external `jq` is needed on the gh path.
+build_gh_filter() {
+    local tag_prefix="$1"
+    local prerelease="$2"
+    local exclude_prefix="$3"
+    local filter
+    if [ -n "$exclude_prefix" ]; then
+        filter='[.[] | select(.tagName | startswith("__PFX__")) | select((.tagName | startswith("__EX__")) | not)] | map(select((.isPrerelease | tostring) == "__PRE__")) | .[0].tagName'
+    else
+        filter='[.[] | select(.tagName | startswith("__PFX__"))] | map(select((.isPrerelease | tostring) == "__PRE__")) | .[0].tagName'
+    fi
+    filter=${filter//__PFX__/$tag_prefix}
+    filter=${filter//__EX__/$exclude_prefix}
+    filter=${filter//__PRE__/$prerelease}
+    printf '%s' "$filter"
+}
+
 # Resolve the version (without prefix) of the latest release for a package.
 #
 # `tag_prefix` must be the exact tag prefix for that package: `openflows-` for
@@ -325,17 +351,12 @@ resolve_tag() {
     local exclude_prefix="${3:-}"
     local tag=""
     if has_cmd gh; then
-        if [ -n "$exclude_prefix" ]; then
-            tag=$(gh release list --repo "$REPO" --limit 100 --json tagName,isPrerelease \
-                -q --arg pfx "$tag_prefix" --arg ex "$exclude_prefix" --arg pre "$prerelease" \
-                '[.[] | select(.tagName | startswith($pfx)) | select((.tagName | startswith($ex)) | not)] | map(select((.isPrerelease | tostring) == $pre)) | .[0].tagName' 2>/dev/null || echo "")
-        else
-            tag=$(gh release list --repo "$REPO" --limit 100 --json tagName,isPrerelease \
-                -q --arg pfx "$tag_prefix" --arg pre "$prerelease" \
-                '[.[] | select(.tagName | startswith($pfx))] | map(select((.isPrerelease | tostring) == $pre)) | .[0].tagName' 2>/dev/null || echo "")
-        fi
+        local filter
+        filter=$(build_gh_filter "$tag_prefix" "$prerelease" "$exclude_prefix")
+        tag=$(gh release list --repo "$REPO" --limit 100 --json tagName,isPrerelease \
+            -q "$filter" 2>/dev/null || echo "")
     fi
-    if [ -z "$tag" ]; then
+    if [ -z "$tag" ] && has_cmd jq; then
         if [ -n "$exclude_prefix" ]; then
             tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>/dev/null \
                 | jq -r --arg pfx "$tag_prefix" --arg ex "$exclude_prefix" --arg pre "$prerelease" \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -238,7 +238,7 @@ download_one() {
 download_binary() {
     local platform="$1"
     local main_version="$2"
-    local harness_version="${3:-$main_version}"
+    local harness_version="${3:-}"
 
     info "Downloading OpenFlows ${main_version} for ${platform}..."
 
@@ -249,12 +249,14 @@ download_binary() {
         return 1
     fi
 
-    # The harness ships in its own release, possibly at its own version;
-    # download it too, but don't fail the whole install if a particular
-    # platform has no harness build.
+    # The harness ships in its own release, possibly at its own version.
+    # Only download it when a harness release exists in the current channel
+    # (harness_version is non-empty); never fall back to the main version, since
+    # the tag encodes no channel and could pull a same-version harness from the
+    # other (stable/edge) channel.
     local harness_dir=""
     local harness_copied=false
-    if download_one "openflows-harness" "$harness_version" "$platform" harness_dir; then
+    if [ -n "$harness_version" ] && download_one "openflows-harness" "$harness_version" "$platform" harness_dir; then
         harness_copied=true
     else
         warn "No openflows-harness binary for ${platform}; skipping harness"
@@ -360,11 +362,11 @@ resolve_tag() {
         if [ -n "$exclude_prefix" ]; then
             tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>/dev/null \
                 | jq -r --arg pfx "$tag_prefix" --arg ex "$exclude_prefix" --arg pre "$prerelease" \
-                '[.[] | select((.prerelease | tostring) == $pre) | select(.tag_name | startswith($pfx)) | select((.tag_name | startswith($ex)) | not)] | .[0].tag_name' 2>/dev/null || echo "")
+                '[.[] | select((.prerelease | tostring) == $pre) | select(.tag_name | startswith($pfx)) | select((.tag_name | startswith($ex)) | not)] | .[0].tag_name // ""' 2>/dev/null || echo "")
         else
             tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>/dev/null \
                 | jq -r --arg pfx "$tag_prefix" --arg pre "$prerelease" \
-                '[.[] | select((.prerelease | tostring) == $pre) | select(.tag_name | startswith($pfx))] | .[0].tag_name' 2>/dev/null || echo "")
+                '[.[] | select((.prerelease | tostring) == $pre) | select(.tag_name | startswith($pfx))] | .[0].tag_name // ""' 2>/dev/null || echo "")
         fi
     fi
     echo "${tag#${tag_prefix}}"


### PR DESCRIPTION
## Summary

Split the single combined release into **two independent GitHub releases**, one per binary, and drop the `v` prefix from release tags.

- **openflows** → tag `openflows-X.Y.Z` → release `openflows`
- **openflows-harness** → tag `openflows-harness-X.Y.Z` → release `openflows-harness`

## Why

Previously `openflows` and `openflows-harness` were `version_group`'d into one tag/release (`v1.2.0`). This PR makes them release independently, each with its own tag and GitHub Release (without a `v` prefix).

## Changes

- **release-plz.toml**: removed `version_group`, added per-package `git_tag_name` (`openflows-{{ version }}` / `openflows-harness-{{ version }}`).
- **.github/workflows/release-assets.yml**: trigger on per-package tags and attach only that package's binaries to its own release.
- **scripts/install.sh**: resolve `openflows-*` stable/edge tags to a bare version and download **both** releases (openflows + openflows-harness) at that version.
- **Cargo manifests**: added missing `version` to internal path dependencies so `release-plz` can run `cargo package` (this was the actual blocker that made `release-pr` report "already up-to-date"/fail).
- **RELEASING.md**: documented the two-release workflow.

## Validation

- `cargo metadata` + `cargo check -p openflows -p openflows-harness` pass.
- `release-plz update` (same version as the action) now completes past `cargo package` and computes next versions independently per package.
- `bash -n scripts/install.sh` passes.