### PR TITLE
chore: bump openflows and openflows-harness to 1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openflows"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "agent-forge",
  "agent-lore",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "openflows-harness"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "a2a-protocol",
  "anyhow",

--- a/binary/Cargo.toml
+++ b/binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "openflows"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 license = "MIT"
 
@@ -25,7 +25,7 @@ agent-sentinel  = { version = "1.1.6", path = "../crates/agent-sentinel" }
 agent-lore      = { version = "0.1.0", path = "../crates/agent-lore" }
 provisioner    = { version = "0.1.0", path = "../crates/provisioner" }
 coder-client    = { version = "0.1.0", path = "../crates/coder-client" }
-openflows-harness = { version = "1.2.0", path = "../crates/openflows-harness" }
+openflows-harness = { version = "1.2.1", path = "../crates/openflows-harness" }
 clap            = { version = "4", features = ["derive"] }
 
   anyhow      = { workspace = true }

--- a/crates/openflows-harness/Cargo.toml
+++ b/crates/openflows-harness/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openflows-harness"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 license = "MIT"
 description = "Typed SharedStore CLI for Coder Agent worker workspaces"


### PR DESCRIPTION
Bumps both released package manifests from `1.2.0` to `1.2.1`.

- `binary/Cargo.toml`: `openflows` `1.2.0` -> `1.2.1`, plus the path dependency `openflows-harness = 1.2.0` -> `1.2.1`
- `crates/openflows-harness/Cargo.toml`: `1.2.0` -> `1.2.1`

Verified: `cargo metadata` resolves both packages at 1.2.1.