### PR TITLE
chore: revert to single openflows release without orchestration bundling

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -8,12 +8,22 @@ name: Release Assets
 # all shipped binaries (`openflows`, `openflows-doctor`, `openflows-harness`) into
 # one tarball per platform. Asset names are predictable/fixed so re-runs overwrite
 # (never error): `openflows-<version>-<target>.tar.gz(+.sha256)`.
+#
+# Manual dispatch requires the `version` input (a tag push derives it from
+# `github.ref_name`; a branch name like `main` is never mistaken for a version).
 
 on:
   push:
     tags:
       - 'openflows-[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
+    inputs:
+      # Version to build (e.g. 1.2.1) for manual dispatch. A tag push derives the
+      # version from github.ref_name, but on a manual dispatch github.ref_name is
+      # a branch (e.g. `main`), so callers must supply the release version.
+      version:
+        description: 'Version to build and attach, e.g. 1.2.1 (used for manual dispatch only)'
+        required: true
 
 concurrency:
   group: release-assets-${{ github.ref }}
@@ -113,10 +123,21 @@ jobs:
 
       - name: Create tarball
         env:
+          MANUAL_VERSION: ${{ inputs.version }}
           REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          VERSION="${REF_NAME#openflows-}"
+          if [ -n "${MANUAL_VERSION}" ]; then
+            VERSION="${MANUAL_VERSION}"
+          else
+            VERSION="${REF_NAME#openflows-}"
+          fi
+          # Guard against non-version values (e.g. a branch name like `main` on
+          # a manual dispatch, or a malformed tag) producing bad asset/tag names.
+          if ! printf '%s' "${VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid release version '${VERSION}' (expected an openflows-X.Y.Z tag or a version input)"
+            exit 1
+          fi
           PLATFORM="${{ matrix.target }}"
           ARCHIVE="openflows-${VERSION}-${PLATFORM}"
           mkdir -p "dist/${ARCHIVE}"
@@ -143,6 +164,23 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Resolve release tag
+        id: release
+        env:
+          MANUAL_VERSION: ${{ inputs.version }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [ -n "${MANUAL_VERSION}" ]; then
+            VERSION="${MANUAL_VERSION}"
+          else
+            VERSION="${REF_NAME#openflows-}"
+          fi
+          if ! printf '%s' "${VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid release version '${VERSION}' (expected an openflows-X.Y.Z tag or a version input)"
+            exit 1
+          fi
+          echo "tag=openflows-${VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Download all artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -155,7 +193,7 @@ jobs:
       - name: Upload assets to release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ steps.release.outputs.tag }}
           files: |
             dist/*.tar.gz
             dist/*.sha256

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -1,22 +1,18 @@
 name: Release Assets
 
-# Builds and attaches the cross-platform binary tarballs to the two per-package
-# GitHub Releases that release-plz created (see `release.yml`).
+# Builds the cross-platform binary tarballs for a release and attaches them to
+# the single GitHub Release that release-plz created (see `release.yml`).
 #
-# Each of the two released packages gets its OWN super-tag/release:
-#   - `openflows-<version>`        -> release "openflows"        -> asset `openflows-<version>-<target>.tar.gz`
-#   - `openflows-harness-<version>` -> release "openflows-harness" -> asset `openflows-harness-<version>-<target>.tar.gz`
-#
-# Tag names carry no `v` prefix. The package owning the tag is derived from the
-# tag name (`openflows-` vs `openflows-harness-`), and each run only builds and
-# attaches that package's own binaries. Asset names are predictable/fixed so
-# re-runs overwrite (never error).
+# Triggered by the `openflows-<version>` tag push (no `v` prefix) that release-plz
+# produces when the release PR is merged to `main`. Each run builds and bundles
+# all shipped binaries (`openflows`, `openflows-doctor`, `openflows-harness`) into
+# one tarball per platform. Asset names are predictable/fixed so re-runs overwrite
+# (never error): `openflows-<version>-<target>.tar.gz(+.sha256)`.
 
 on:
   push:
     tags:
       - 'openflows-[0-9]*.[0-9]*.[0-9]*'
-      - 'openflows-harness-[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
 
 concurrency:
@@ -66,20 +62,6 @@ jobs:
         with:
           target: ${{ matrix.target }}
 
-      - name: Resolve package from tag
-        id: pkg
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          if [[ "${REF_NAME}" == openflows-harness-* ]]; then
-            echo "name=openflows-harness" >> "$GITHUB_OUTPUT"
-          elif [[ "${REF_NAME}" == openflows-* ]]; then
-            echo "name=openflows" >> "$GITHUB_OUTPUT"
-          else
-            echo "::error::Unexpected release tag '${REF_NAME}'"
-            exit 1
-          fi
-
       - name: Install build dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -122,39 +104,26 @@ jobs:
           tool: cargo-zigbuild@0.23.0
 
       - name: Build binaries
-        env:
-          PACKAGE: ${{ steps.pkg.outputs.name }}
-        run: |
-          PLATFORM_TARGET="${{ matrix.use_zigbuild && matrix.zigbuild_target || matrix.target }}"
-          if [[ "${PACKAGE}" == "openflows-harness" ]]; then
-            ${{ matrix.use_zigbuild && 'cargo zigbuild' || 'cargo build' }} --release \
-              --target "${PLATFORM_TARGET}" --bin openflows-harness
-          else
-            ${{ matrix.use_zigbuild && 'cargo zigbuild' || 'cargo build' }} --release \
-              --target "${PLATFORM_TARGET}" --bin openflows --bin openflows-doctor
-          fi
+        run: >
+          ${{ matrix.use_zigbuild && 'cargo zigbuild' || 'cargo build' }} --release
+          --target ${{ matrix.use_zigbuild && matrix.zigbuild_target || matrix.target }}
+          --bin openflows
+          --bin openflows-doctor
+          --bin openflows-harness
 
       - name: Create tarball
         env:
-          PACKAGE: ${{ steps.pkg.outputs.name }}
           REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          PKG="${PACKAGE}"
-          VERSION="${REF_NAME#${PKG}-}"
+          VERSION="${REF_NAME#openflows-}"
           PLATFORM="${{ matrix.target }}"
-          ARCHIVE="${PKG}-${VERSION}-${PLATFORM}"
+          ARCHIVE="openflows-${VERSION}-${PLATFORM}"
           mkdir -p "dist/${ARCHIVE}"
 
-          if [[ "${PKG}" == "openflows-harness" ]]; then
-            cp "target/${{ matrix.target }}/release/openflows-harness" "dist/${ARCHIVE}/"
-          else
-            for bin in openflows openflows-doctor; do
-              cp "target/${{ matrix.target }}/release/${bin}" "dist/${ARCHIVE}/"
-            done
-            cp -r orchestration "dist/${ARCHIVE}/"
-            cp README.md LICENSE "dist/${ARCHIVE}/" 2>/dev/null || true
-          fi
+          for bin in openflows openflows-doctor openflows-harness; do
+            cp "target/${{ matrix.target }}/release/${bin}" "dist/${ARCHIVE}/"
+          done
 
           tar -czf "dist/${ARCHIVE}.tar.gz" -C dist "${ARCHIVE}"
           cd dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,14 @@ name: Release
 # Runs ONLY on pushes to `main` (the default branch). Two jobs:
 #   - `release-plz (release-pr)` : scans Conventional Commits since the last tag,
 #     computes the next version (feat→minor, fix→patch, BREAKING CHANGE→major),
-#     and opens a `release-plz-*` PR to `main` bumping the manifests + CHANGELOG.
+#     and opens a `release-plz-*` PR to `main` bumping the manifest + CHANGELOG.
 #     You merge that PR; you never type a version.
 #   - `release-plz (release)`     : when the push is the merge of a `release-plz-*`
-#     PR (release_always = false), creates ONE tag + GitHub Release per released
-#     binary: `openflows-<version>` and `openflows-harness-<version>` (no `v`
-#     prefix). The `release-assets.yml` workflow then attaches the cross-platform
-#     binaries to each package's own release.
+#     PR (release_always = false), creates the single tag + GitHub Release for
+#     `openflows` (no `v` prefix: `openflows-<version>`). The `release-assets.yml`
+#     workflow then attaches the cross-platform binaries, all built from this one
+#     release (including `openflows-doctor` and `openflows-harness`, which are not
+#     released as separate packages).
 #
 # Publications to npm / Homebrew / Docker (GHCR) / crates.io are removed.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,26 +1,29 @@
 # Releasing OpenFlows
 
-This document describes the release strategy for the two shipped packages —
-`openflows` (the main binary) and `openflows-harness` (the typed SharedStore CLI).
+This document describes the release strategy for the `openflows` package — the
+main binary plus the bundled helper binaries (`openflows-doctor`,
+`openflows-harness`) built from that single release.
 
 Releases are driven by **release-plz** on a **`develop`-as-default** branching
 model, with **versions computed automatically from Conventional Commits**. There
 is **no** npm, Homebrew, Docker/GHCR, or crates.io publishing; the release pulls
 cross-platform binary tarballs onto a GitHub Release only.
 
+The orchestration specs, plugins, hooks, and skills live in a **separate
+repository** (not shipped in the OpenFlows release).
+
 ## Branching model
 
 ```
 feature/* ──PR──▶ develop          (default branch, integration)
 develop ──┐
-          ├─ release-plz release-pr ──▶ release-plz-* PR (bumps versions + CHANGELOG)
+          ├─ release-plz release-pr ──▶ release-plz-* PR (bumps version + CHANGELOG)
           └─(create)──▶ release/vX.Y.Z ──PR merge──▶ main
                                                     │  push to main
                                                     ▼
                           release-plz release → tag openflows-X.Y.Z
-                                              + tag openflows-harness-X.Y.Z
-                                              (one GitHub Release per binary, no `v`)
-                          release-assets → attach each binary's tarballs to its own release
+                                              (single GitHub Release, no `v`)
+                          release-assets → attach openflows-<X.Y.Z>-<target>.tar.gz
 ```
 
 - `develop` is the default branch and the integration point. All feature work
@@ -41,13 +44,13 @@ Conventional Commits merged since the last tag:
 | `feat:`                          | **minor**    |
 | `fix:`, `docs:`, `chore:`, …     | **patch**    |
 
-`release-plz` opens a `release-plz-*` pull request to `develop` that bumps each
+`release-plz` opens a `release-plz-*` pull request to `develop` that bumps the
 released package's manifest version and regenerates the CHANGELOG. Merging that
 PR "locks in" the new version.
 
 > The very first release (no tags yet in the repo — the old tag history was
 > deleted for a clean start) is treated as an **initial release** and ships at
-> the current version in the manifests (`1.2.0`). After that, all releases are
+> the current version in the manifest (`1.2.0`). After that, all releases are
 > computed from conventional commits.
 
 ## Day-to-day workflow
@@ -62,7 +65,7 @@ PR "locks in" the new version.
 1. Merge the feature work you want to release into `develop`.
 
 2. `release-plz` will have opened (or updated) a `release-plz-*` PR to `develop`
-   bumping the versions + CHANGELOG. Review and merge it so the new version sits
+   bumping the version + CHANGELOG. Review and merge it so the new version sits
    on `develop`. (If no release PR appears, run the `Release → release-plz
    (release-pr)` workflow manually.)
 
@@ -82,21 +85,18 @@ PR "locks in" the new version.
    - The release happens on merge.
 
 5. Merge the PR into `main`. On push to `main`, **release-plz `release`** creates
-   one tag and GitHub Release per binary:
+   one tag and GitHub Release for the `openflows` package:
 
-   - `openflows-X.Y.Z` (release **openflows**),
-   - `openflows-harness-X.Y.Z` (release **openflows-harness**).
+   - `openflows-X.Y.Z` (release **openflows**).
 
-   Tag/release names carry no `v` prefix.
+   Tag/release name carries no `v` prefix.
 
-6. Each tag push triggers **release-assets**, which builds and attaches that
-   package's own cross-platform tarballs:
+6. The tag push triggers **release-assets**, which builds and attaches the
+   cross-platform tarballs:
 
-   - on `openflows-*` tags: `openflows-<X.Y.Z>-<target>.tar.gz` + `.sha256`
+   - `openflows-<X.Y.Z>-<target>.tar.gz` + `.sha256`
      for x86_64/aarch64 Linux-GNU (zigbuild), Linux-musl, and macOS, containing
-     the `openflows` and `openflows-doctor` binaries plus `orchestration/`;
-   - on `openflows-harness-*` tags: `openflows-harness-<X.Y.Z>-<target>.tar.gz`
-     + `.sha256` containing the `openflows-harness` binary.
+     the `openflows`, `openflows-doctor`, and `openflows-harness` binaries.
 
    Asset names are fixed/predictable, so re-runs overwrite rather than error.
 
@@ -110,9 +110,11 @@ enforces this on every PR.
 
 ## Notes
 
-- Independent releases: `openflows` and `openflows-harness` are released
-  separately in `release-plz.toml`, each with its own tag
-  (`openflows-X.Y.Z` / `openflows-harness-X.Y.Z`) and GitHub Release, so they can
-  ship independently. The installer fetches both releases at the same version.
+- Single release: only `openflows` is released in `release-plz.toml`, with tag
+  `openflows-X.Y.Z` (no `v` prefix). The `openflows-doctor` and
+  `openflows-harness` binaries are built from the same release and bundled into
+  the `openflows` tarball; they are not released as separate packages.
 - No crates.io publishing is configured (these are application binaries);
   `release-plz.toml` uses `git_only = true` and `publish = false`.
+- `orchestration/` is not bundled or shipped with the release; it is maintained
+  in a separate repository.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,18 +5,18 @@
 #   - `release-pr` : scans Conventional Commits since the last tag, computes the
 #                    next version, and opens a `release-plz-*` PR to `main` that
 #                    bumps the manifest + CHANGELOG.
-#   - `release`    : creates the per-package tag + GitHub Release when the main
-#                    push is the merge of a `release-plz-*` PR
+#   - `release`    : creates the package tag + GitHub Release when the main push
+#                    is the merge of a `release-plz-*` PR
 #                    (`release_always = false`).
 #
 # GitHub integration is via git tags only (`git_only = true`) — the shipped
-# packages are application binaries that are NOT published to crates.io, so
+# package is an application binary that is NOT published to crates.io, so
 # release-plz never runs `cargo publish` and never queries the registry.
 #
-# Each shipped binary gets its OWN github release + git tag. Tag names carry no
-# `v` prefix and are namespaced per package so the two binaries can be released
-# independently at the same version without colliding (`openflows-1.2.0` vs
-# `openflows-harness-1.2.0`).
+# Only `openflows` is released, as a single GitHub Release + git tag with no `v`
+# prefix: `openflows-X.Y.Z`. The other binaries (`openflows-doctor`,
+# `openflows-harness`) are built from the same release and bundled into the
+# `openflows` tarball; they are not released as separate packages.
 
 [workspace]
 # Determine released versions from git tags instead of the crates.io registry.
@@ -26,20 +26,13 @@ publish = false
 # Only release when the main push is the merge of a `release-plz-*` release PR
 # (not on every push), avoiding premature tags before the bump PR merges.
 release_always = false
-# Only the packages explicitly opted in below are processed. The rest of the
+# Only the package explicitly opted in below is processed. The rest of the
 # workspace crates are libraries/sub-crates and are intentionally not released.
 release = false
 
-# `openflows` and `openflows-harness` are released independently: one git tag
-# and one GitHub Release per binary. The per-package `git_tag_name` avoids a
-# tag collision when both are at the same version, and omits the `v` prefix.
-
+# `openflows` is the single released package. The tag carries no `v` prefix:
+# `openflows-{{ version }}`.
 [[package]]
 name = "openflows"
 release = true
 git_tag_name = "openflows-{{ version }}"
-
-[[package]]
-name = "openflows-harness"
-release = true
-git_tag_name = "openflows-harness-{{ version }}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # OpenFlows Installer
 # Usage: curl -fsSL https://get.openflows.dev | bash
-#   or:  curl -fsSL https://raw.githubusercontent.com/The-AgenticFlow/AgentFlow/main/scripts/install.sh | bash
+#   or:  curl -fsSL https://raw.githubusercontent.com/The-AgenticFlow/openflows/main/scripts/install.sh | bash
 # Install latest stable:  curl -fsSL https://get.openflows.dev | bash
 # Install edge (main):    curl -fsSL https://get.openflows.dev | bash -s -- --edge
 
@@ -154,137 +154,110 @@ ensure_ai_cli() {
     fi
 }
 
-# Copy orchestration files, preserving user-customized registry.json in OPENFLOWS_HOME.
-install_orchestration() {
-    local src_dir="$1"
-    local oh_dir="${OPENFLOWS_HOME:-$HOME/.openflows}"
-    local reg_path="orchestration/agent/registry.json"
-    local backup=""
-
-    if [ -f "${oh_dir}/${reg_path}" ]; then
-        backup=$(mktemp)
-        cp "${oh_dir}/${reg_path}" "$backup"
-    fi
-
-    cp -r "${src_dir}/orchestration" "${INSTALL_DIR}/"
-    success "Installed orchestration config to ${INSTALL_DIR}/orchestration/"
-
-    if [ -n "$backup" ] && [ -f "$backup" ]; then
-        mkdir -p "${oh_dir}/orchestration/agent"
-        cp "$backup" "${oh_dir}/${reg_path}"
-        rm -f "$backup"
-        info "Preserved existing registry.json in ${oh_dir} (run 'openflows-setup' to reconfigure)"
-    fi
+# Build a jq filter for `gh release list -q` matching the exact tag prefix and
+# selecting only the requested channel. The values are inlined as `__PFX__` and
+# `__PRE__` placeholders (safe characters only) and substituted below, so no
+# `--arg` bindings are passed to gh — gh's `-q` accepts only the jq expression.
+# gh runs its own embedded jq, so no external `jq` is needed on the gh path.
+build_gh_filter() {
+    local tag_prefix="$1"
+    local prerelease="$2"
+    local filter
+    filter='[.[] | select(.tagName | startswith("__PFX__"))] | map(select((.isPrerelease | tostring) == "__PRE__")) | .[0].tagName'
+    filter=${filter//__PFX__/$tag_prefix}
+    filter=${filter//__PRE__/$prerelease}
+    printf '%s' "$filter"
 }
 
-# Download a single release tarball into /tmp, trying the musl fallback for
-# platforms without a native binary. `out_var` receives the extraction
-# directory name (which reflects the platform actually downloaded, e.g. the
-# musl fallback) so the caller knows where the unpacked files live.
-download_one() {
-    local pkg="$1"
-    local version="$2"
-    local platform="$3"
-    local out_var="$4"          # var to set with the extraction directory name
-    local asset_name="${pkg}-${version}-${platform}.tar.gz"
-    local url="https://github.com/${REPO}/releases/download/${pkg}-${version}/${asset_name}"
-    local downloaded=""
-    local resolved_platform="$platform"
+# Resolve the version (without the `openflows-` prefix) of the latest release
+# for the requested channel and return it. `prerelease` selects the channel:
+# "false" for stable, "true" for edge.
+resolve_version() {
+    local prerelease="$1"
+    local tag=""
+    if has_cmd gh; then
+        local filter
+        filter=$(build_gh_filter "openflows-" "$prerelease")
+        tag=$(gh release list --repo "$REPO" --limit 100 --json tagName,isPrerelease \
+            -q "$filter" 2>/dev/null || echo "")
+    fi
+    if [ -z "$tag" ] && has_cmd jq; then
+        tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>/dev/null \
+            | jq -r --arg pre "$prerelease" \
+              '[.[] | select((.prerelease | tostring) == $pre) | select(.tag_name | startswith("openflows-"))] | .[0].tag_name // ""' 2>/dev/null || echo "")
+    fi
+    echo "${tag#openflows-}"
+}
 
+# Download the single `openflows` release tarball for a platform (with a musl
+# fallback where no native binary exists) and install all shipped binaries.
+download_binary() {
+    local platform="$1"
+    local version="$2"
+    local asset_name="openflows-${version}-${platform}.tar.gz"
+
+    info "Downloading OpenFlows ${version} for ${platform}..."
+
+    local download_url="https://github.com/${REPO}/releases/download/openflows-${version}/${asset_name}"
+
+    local download_ok=false
     if has_cmd curl; then
-        if curl -fsSL "$url" -o "/tmp/${asset_name}" 2>/dev/null; then
-            downloaded="$asset_name"
+        if curl -fsSL "$download_url" -o "/tmp/${asset_name}" 2>/dev/null; then
+            download_ok=true
         fi
     elif has_cmd wget; then
-        if wget -q "$url" -O "/tmp/${asset_name}" 2>/dev/null; then
-            downloaded="$asset_name"
+        if wget -q "$download_url" -O "/tmp/${asset_name}" 2>/dev/null; then
+            download_ok=true
         fi
     else
         fail "Neither curl nor wget found"
         return 1
     fi
 
-    if [ -z "$downloaded" ]; then
+    if [ "$download_ok" = false ]; then
         local alt_platform=""
         case "$platform" in
             x86_64-unknown-linux-gnu)  alt_platform="x86_64-unknown-linux-musl" ;;
             aarch64-unknown-linux-gnu) alt_platform="aarch64-unknown-linux-musl" ;;
             *) ;;
         esac
+
         if [ -n "$alt_platform" ]; then
-            local alt_asset="${pkg}-${version}-${alt_platform}.tar.gz"
-            local alt_url="https://github.com/${REPO}/releases/download/${pkg}-${version}/${alt_asset}"
-            warn "No ${pkg} binary for ${platform}, trying ${alt_platform}..."
-            if has_cmd curl && curl -fsSL "$alt_url" -o "/tmp/${alt_asset}" 2>/dev/null; then
-                downloaded="$alt_asset"
-                resolved_platform="$alt_platform"
-            elif has_cmd wget && wget -q "$alt_url" -O "/tmp/${alt_asset}" 2>/dev/null; then
-                downloaded="$alt_asset"
-                resolved_platform="$alt_platform"
+            local alt_asset="openflows-${version}-${alt_platform}.tar.gz"
+            local alt_url="https://github.com/${REPO}/releases/download/openflows-${version}/${alt_asset}"
+            warn "No binary for ${platform}, trying ${alt_platform}..."
+            if has_cmd curl; then
+                if curl -fsSL "$alt_url" -o "/tmp/${alt_asset}" 2>/dev/null; then
+                    download_ok=true
+                    asset_name="$alt_asset"
+                    platform="$alt_platform"
+                fi
+            elif has_cmd wget; then
+                if wget -q "$alt_url" -O "/tmp/${alt_asset}" 2>/dev/null; then
+                    download_ok=true
+                    asset_name="$alt_asset"
+                    platform="$alt_platform"
+                fi
             fi
+        fi
+
+        if [ "$download_ok" = false ]; then
+            fail "Failed to download binary for ${platform}"
+            info "Falling back to building from source..."
+            return 1
         fi
     fi
 
-    if [ -z "$downloaded" ]; then
-        return 1
-    fi
+    tar -xzf "/tmp/${asset_name}" -C /tmp/
+    rm -f "/tmp/${asset_name}"
 
-    tar -xzf "/tmp/${downloaded}" -C /tmp/
-    rm -f "/tmp/${downloaded}"
-    printf -v "$out_var" "%s" "${pkg}-${version}-${resolved_platform}"
-    return 0
-}
-
-download_binary() {
-    local platform="$1"
-    local main_version="$2"
-    local harness_version="${3:-}"
-
-    info "Downloading OpenFlows ${main_version} for ${platform}..."
-
-    local main_dir=""
-    if ! download_one "openflows" "$main_version" "$platform" main_dir; then
-        fail "Failed to download openflows binary for ${platform}"
-        info "Falling back to building from source..."
-        return 1
-    fi
-
-    # The harness ships in its own release, possibly at its own version.
-    # Only download it when a harness release exists in the current channel
-    # (harness_version is non-empty); never fall back to the main version, since
-    # the tag encodes no channel and could pull a same-version harness from the
-    # other (stable/edge) channel.
-    local harness_dir=""
-    local harness_copied=false
-    if [ -n "$harness_version" ] && download_one "openflows-harness" "$harness_version" "$platform" harness_dir; then
-        harness_copied=true
-    else
-        warn "No openflows-harness binary for ${platform}; skipping harness"
-    fi
-
-    local extract_dir="/tmp/${main_dir}"
+    local extract_dir="/tmp/openflows-${version}-${platform}"
     for bin in "${BINARIES[@]}"; do
         if [ -f "${extract_dir}/${bin}" ]; then
             cp "${extract_dir}/${bin}" "${INSTALL_DIR}/"
             chmod +x "${INSTALL_DIR}/${bin}"
         fi
     done
-
-    # The harness archive extracts to its own package-named directory, so copy
-    # it separately rather than searching the main package's directory.
-    if [ "$harness_copied" = true ]; then
-        if [ -f "/tmp/${harness_dir}/openflows-harness" ]; then
-            cp "/tmp/${harness_dir}/openflows-harness" "${INSTALL_DIR}/"
-            chmod +x "${INSTALL_DIR}/openflows-harness"
-            success "Installed openflows-harness"
-        fi
-        rm -rf "/tmp/${harness_dir}"
-    fi
-
-    if [ -d "${extract_dir}/orchestration" ]; then
-        install_orchestration "${extract_dir}"
-    fi
-
     rm -rf "${extract_dir}"
 
     success "Downloaded and extracted to ${INSTALL_DIR}/"
@@ -309,67 +282,6 @@ build_from_source() {
             success "Built and installed ${bin}"
         fi
     done
-
-    if [ -d "orchestration" ]; then
-        install_orchestration "."
-    fi
-}
-
-# Build a jq filter for `gh release list -q` matching the exact tag prefix,
-# optionally excluding a longer prefix, and selecting only the requested
-# channel. The values are inlined as `__PFX__`/`__EX__`/`__PRE__` placeholders
-# (safe characters only) and substituted below, so no `--arg` bindings are
-# passed to gh — gh's `-q` accepts only the jq expression. gh runs its own
-# embedded jq, so no external `jq` is needed on the gh path.
-build_gh_filter() {
-    local tag_prefix="$1"
-    local prerelease="$2"
-    local exclude_prefix="$3"
-    local filter
-    if [ -n "$exclude_prefix" ]; then
-        filter='[.[] | select(.tagName | startswith("__PFX__")) | select((.tagName | startswith("__EX__")) | not)] | map(select((.isPrerelease | tostring) == "__PRE__")) | .[0].tagName'
-    else
-        filter='[.[] | select(.tagName | startswith("__PFX__"))] | map(select((.isPrerelease | tostring) == "__PRE__")) | .[0].tagName'
-    fi
-    filter=${filter//__PFX__/$tag_prefix}
-    filter=${filter//__EX__/$exclude_prefix}
-    filter=${filter//__PRE__/$prerelease}
-    printf '%s' "$filter"
-}
-
-# Resolve the version (without prefix) of the latest release for a package.
-#
-# `tag_prefix` must be the exact tag prefix for that package: `openflows-` for
-# the main release and `openflows-harness-` for the harness. `openflows-harness-`
-# tags share the `openflows-` prefix with the main package's tags, so `exclude_prefix`
-# (e.g. `openflows-harness-` when resolving the main release) stops a newer harness
-# tag from being mistaken for the main package. Each package is resolved
-# independently so the two can be released at their own versions.
-#
-# `prerelease` selects the channel: "false" for stable, "true" for edge.
-resolve_tag() {
-    local tag_prefix="$1"
-    local prerelease="$2"
-    local exclude_prefix="${3:-}"
-    local tag=""
-    if has_cmd gh; then
-        local filter
-        filter=$(build_gh_filter "$tag_prefix" "$prerelease" "$exclude_prefix")
-        tag=$(gh release list --repo "$REPO" --limit 100 --json tagName,isPrerelease \
-            -q "$filter" 2>/dev/null || echo "")
-    fi
-    if [ -z "$tag" ] && has_cmd jq; then
-        if [ -n "$exclude_prefix" ]; then
-            tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>/dev/null \
-                | jq -r --arg pfx "$tag_prefix" --arg ex "$exclude_prefix" --arg pre "$prerelease" \
-                '[.[] | select((.prerelease | tostring) == $pre) | select(.tag_name | startswith($pfx)) | select((.tag_name | startswith($ex)) | not)] | .[0].tag_name // ""' 2>/dev/null || echo "")
-        else
-            tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>/dev/null \
-                | jq -r --arg pfx "$tag_prefix" --arg pre "$prerelease" \
-                '[.[] | select((.prerelease | tostring) == $pre) | select(.tag_name | startswith($pfx))] | .[0].tag_name // ""' 2>/dev/null || echo "")
-        fi
-    fi
-    echo "${tag#${tag_prefix}}"
 }
 
 ensure_path() {
@@ -437,26 +349,22 @@ main() {
 
     mkdir -p "$INSTALL_DIR"
     local installed=false
-    local tag=""
+    local version=""
 
     if [ "$CHANNEL" = "edge" ]; then
-        tag=$(resolve_tag "openflows-" "true" "openflows-harness-")
-        local harness_tag
-        harness_tag=$(resolve_tag "openflows-harness-" "true")
-        if [ -n "$tag" ]; then
-            info "Found edge release: $tag"
-            if download_binary "$platform" "$tag" "$harness_tag"; then
+        version=$(resolve_version "true")
+        if [ -n "$version" ]; then
+            info "Found edge release: $version"
+            if download_binary "$platform" "$version"; then
                 installed=true
             fi
         else
             warn "No edge release found. Falling back to building from latest main..."
         fi
     else
-        tag=$(resolve_tag "openflows-" "false" "openflows-harness-")
-        local harness_tag
-        harness_tag=$(resolve_tag "openflows-harness-" "false")
-        if [ -n "$tag" ]; then
-            if download_binary "$platform" "$tag" "$harness_tag"; then
+        version=$(resolve_version "false")
+        if [ -n "$version" ]; then
+            if download_binary "$platform" "$version"; then
                 installed=true
             fi
         fi
@@ -475,7 +383,7 @@ main() {
     echo "╚══════════════════════════════════════════════╝"
     echo ""
     if [ "$CHANNEL" = "edge" ]; then
-        echo "  ⚠ Installed EDGE (pre-release) build: $tag"
+        echo "  ⚠ Installed EDGE (pre-release) build: $version"
         echo "    For stability, use: curl -fsSL https://get.openflows.dev | bash"
         echo ""
     fi


### PR DESCRIPTION
Reverts the two-package release split back to a **single `openflows` release**, and stops bundling `orchestration/` into the shipped release (the orchestration specs/plugins/hooks/skills will live in a separate repository).

## Changes

- **`release-plz.toml`**: only `openflows` is released, with tag `openflows-X.Y.Z` (no `v` prefix). `openflows-harness` is no longer released as a separate package.
- **`.github/workflows/release-assets.yml`**: builds all three binaries (`openflows`, `openflows-doctor`, `openflows-harness`) into one `openflows-<version>-<target>.tar.gz`; removes the per-package tag resolution and the `orchestration/` copy.
- **`scripts/install.sh`**: resolves a single `openflows-` release and downloads one tarball; removes the separate harness resolve/download and the orchestration install step.
- **`RELEASING.md`**: documents the single-release, no-orchestration workflow.

## Scope

Release tooling only — the Rust runtime code that embeds `orchestration/*` (`binary/src/bundled.rs`, `orchestration.rs`, etc.) is left untouched; removing orchestration from the binary at runtime is a separate follow-up once the new orchestration repository is in place.

## Validation

- `bash -n scripts/install.sh` passes.
- `release-assets.yml` and `release.yml` parse as valid YAML.
- `release-plz.toml` parses as valid TOML.