### PR TITLE
chore: finalize single-bundle release from develop to main

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -1,10 +1,12 @@
 name: Release Branch Guard
 
-# Enforces the release-source model for `main` (the default branch). Only these
-# PR sources may target `main`:
-#   - `develop`          : the integration branch is merged into `main` normally.
-#   - `release-plz-*`    : release-plz's auto-generated version-bump PRs.
-#   - `release/vX.Y.Z`   : release branches cut from `develop` (release/vX.Y.Z).
+# Enforces the release-source model for `main` (release-only; `develop` is the
+# default branch). Only these PR sources may target `main`:
+#   - `develop`       : the integration branch is merged into `main` to trigger
+#                       a release.
+#   - `release-plz-*` : release-plz's auto-generated version-bump PRs, which open
+#                       on a push to `main` and merge back into `main` to lock in
+#                       the computed version before the tag + GitHub Release fire.
 # Any other PR to `main` is rejected. Additionally, the PR must originate from
 # this repository (not a fork), so contributors cannot impersonate an allowed
 # source branch name.
@@ -42,10 +44,9 @@ jobs:
           HEAD_BRANCH: ${{ github.head_ref }}
         run: |
           if [[ "${HEAD_BRANCH}" == "develop" ]] \
-            || [[ "${HEAD_BRANCH}" == release-plz-* ]] \
-            || [[ "${HEAD_BRANCH}" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            || [[ "${HEAD_BRANCH}" == release-plz-* ]]; then
             echo "PR source '${HEAD_BRANCH}' is allowed to target main."
             exit 0
           fi
-          echo "::error::PRs to 'main' must come from 'develop', a 'release-plz-*' branch, or a 'release/vX.Y.Z' branch (got '${HEAD_BRANCH}')."
+          echo "::error::PRs to 'main' must come from 'develop' or a 'release-plz-*' branch (got '${HEAD_BRANCH}')."
           exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Release
 
 # Auto-releases from Conventional Commits (see release-plz.toml).
 #
-# Runs ONLY on pushes to `main` (the default branch). Two jobs:
+# Runs ONLY on pushes to `main` (release-only; `develop` is the default branch).
+# Two jobs:
 #   - `release-plz (release-pr)` : scans Conventional Commits since the last tag,
 #     computes the next version (feat→minor, fix→patch, BREAKING CHANGE→major),
 #     and opens a `release-plz-*` PR to `main` bumping the manifest + CHANGELOG.
@@ -13,6 +14,10 @@ name: Release
 #     workflow then attaches the cross-platform binaries, all built from this one
 #     release (including `openflows-doctor` and `openflows-harness`, which are not
 #     released as separate packages).
+#
+# Release flow: only `develop` merges into `main`, which triggers `release-pr`;
+# the resulting `release-plz-*` version-bump PR merges back into `main` and
+# triggers `release`. The `release-branch.yml` guard enforces this source model.
 #
 # Publications to npm / Homebrew / Docker (GHCR) / crates.io are removed.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,8 @@
 # Releasing OpenFlows
 
 This document describes the release strategy for the `openflows` package — the
-main binary plus the bundled helper binaries (`openflows-doctor`,
-`openflows-harness`) built from that single release.
+main binary (`openflows`) plus the bundled helper binaries
+(`openflows-doctor`, `openflows-harness`), all built from that single release.
 
 Releases are driven by **release-plz** on a **`develop`-as-default** branching
 model, with **versions computed automatically from Conventional Commits**. There
@@ -16,20 +16,23 @@ repository** (not shipped in the OpenFlows release).
 
 ```
 feature/* ──PR──▶ develop          (default branch, integration)
-develop ──┐
-          ├─ release-plz release-pr ──▶ release-plz-* PR (bumps version + CHANGELOG)
-          └─(create)──▶ release/vX.Y.Z ──PR merge──▶ main
-                                                    │  push to main
-                                                    ▼
-                          release-plz release → tag openflows-X.Y.Z
-                                              (single GitHub Release, no `v`)
-                          release-assets → attach openflows-<X.Y.Z>-<target>.tar.gz
+develop ──PR merge──▶ main          (release-only; guard enforces develop-only)
+                     │  push to main → release-plz release-pr
+                     ▼
+        release-plz-* PR (version bump + CHANGELOG) ──▶ main
+                     │  merge of that PR → release-plz release
+                     ▼
+        tag openflows-X.Y.Z + single GitHub Release (no `v`)
+                     ▼
+        release-assets → attach openflows-<X.Y.Z>-<target>.tar.gz
+                         (bundles openflows, openflows-doctor, openflows-harness)
 ```
 
-- `develop` is the default branch and the integration point. All feature work
-  lands here via PR (CI + review required).
-- `main` is release-only. It only ever receives merges of `release/vX.Y.Z`
-  branches. A guard workflow rejects any other PR to `main`.
+- `develop` is the **default branch** and the integration point. All feature
+  work lands here via PR (CI + review required).
+- `main` is **release-only**. Only `develop` (and release-plz's own
+  `release-plz-*` version-bump PRs) may be merged into `main`. A guard workflow
+  (`release-branch.yml`) rejects any other PR to `main`.
 - release-plz is the sole publisher; the `release-assets` workflow attaches
   binaries.
 
@@ -44,9 +47,9 @@ Conventional Commits merged since the last tag:
 | `feat:`                          | **minor**    |
 | `fix:`, `docs:`, `chore:`, …     | **patch**    |
 
-`release-plz` opens a `release-plz-*` pull request to `develop` that bumps the
+`release-plz` opens a `release-plz-*` pull request to `main` that bumps the
 released package's manifest version and regenerates the CHANGELOG. Merging that
-PR "locks in" the new version.
+PR "locks in" the new version and triggers the tag + GitHub Release.
 
 > The very first release (no tags yet in the repo — the old tag history was
 > deleted for a clean start) is treated as an **initial release** and ships at
@@ -62,41 +65,32 @@ PR "locks in" the new version.
 
 ## Cutting a release
 
-1. Merge the feature work you want to release into `develop`.
+1. Open a PR from `develop` into `main` and merge it.
 
-2. `release-plz` will have opened (or updated) a `release-plz-*` PR to `develop`
-   bumping the version + CHANGELOG. Review and merge it so the new version sits
-   on `develop`. (If no release PR appears, run the `Release → release-plz
-   (release-pr)` workflow manually.)
+   - The release-branch guard requires the PR to come from `develop` (or a
+     `release-plz-*` branch).
+   - Merging `develop` → `main` is the single action that triggers the release.
 
-3. Cut a release branch from `develop` carrying that version:
+2. On the push to `main`, **release-plz `release-pr`** opens (or updates) a
+   `release-plz-*` PR to `main` bumping the version + CHANGELOG. Review and
+   merge it so the new version is locked in on `main`. (If no release PR
+   appears, run the `Release → release-plz (release-pr)` workflow manually.)
 
-   ```
-   git checkout develop
-   git pull
-   git checkout -b release/vX.Y.Z
-   ```
-
-   The `X.Y.Z` in the branch name should match the version set by release-plz.
-
-4. Open a PR from `release/vX.Y.Z` into `main`.
-
-   - The release-branch guard requires the name to match `release/vX.Y.Z`.
-   - The release happens on merge.
-
-5. Merge the PR into `main`. On push to `main`, **release-plz `release`** creates
-   one tag and GitHub Release for the `openflows` package:
+3. Merging that `release-plz-*` PR pushes `main` again, which triggers
+   **release-plz `release`** — it creates one tag and GitHub Release for the
+   `openflows` package:
 
    - `openflows-X.Y.Z` (release **openflows**).
 
    Tag/release name carries no `v` prefix.
 
-6. The tag push triggers **release-assets**, which builds and attaches the
+4. The tag push triggers **release-assets**, which builds and attaches the
    cross-platform tarballs:
 
    - `openflows-<X.Y.Z>-<target>.tar.gz` + `.sha256`
-     for x86_64/aarch64 Linux-GNU (zigbuild), Linux-musl, and macOS, containing
-     the `openflows`, `openflows-doctor`, and `openflows-harness` binaries.
+     for x86_64/aarch64 Linux-GNU (zigbuild), Linux-musl, and macOS, each
+     containing the `openflows`, `openflows-doctor`, and `openflows-harness`
+     binaries.
 
    Asset names are fixed/predictable, so re-runs overwrite rather than error.
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,13 +1,17 @@
 # release-plz configuration.
 #
 # Drives the release workflow (`.github/workflows/release.yml`), which runs ONLY
-# on pushes to `main` (the default branch):
+# on pushes to `main` (release-only; `develop` is the default branch):
 #   - `release-pr` : scans Conventional Commits since the last tag, computes the
 #                    next version, and opens a `release-plz-*` PR to `main` that
 #                    bumps the manifest + CHANGELOG.
 #   - `release`    : creates the package tag + GitHub Release when the main push
 #                    is the merge of a `release-plz-*` PR
 #                    (`release_always = false`).
+#
+# Release flow: only `develop` merges into `main`, which triggers `release-pr`;
+# the resulting `release-plz-*` version-bump PR merges back into `main` and
+# triggers `release`. The `release-branch.yml` guard enforces this source model.
 #
 # GitHub integration is via git tags only (`git_only = true`) — the shipped
 # package is an application binary that is NOT published to crates.io, so


### PR DESCRIPTION
## Summary

Finalizes the release strategy around a single `openflows` release that bundles all three shipped binaries (`openflows`, `openflows-doctor`, `openflows-harness`), with `develop` as the default branch and only `develop` merged into `main` to trigger the release.

## Changes

- **Default branch**: `develop` is now the default branch on GitHub (already done via repo settings).
- **`.github/workflows/release-branch.yml`**: Restricts PRs to `main` to `develop` and `release-plz-*` only. Removes the old `release/vX.Y.Z` release-branch allowance.
- **`.github/workflows/release.yml`**: Updated comments to clarify `main` is release-only and `develop` is the default; release-plz `release-pr` runs on every merge to `main`.
- **`release-plz.toml`**: Documented the develop→main release flow.
- **`RELEASING.md`**: Rewrote the branching model and "cutting a release" steps to match the actual flow: only `develop` merges into `main` (guarded), which triggers release-pr; the resulting `release-plz-*` PR merges back into `main` and fires the tag + single GitHub Release with the cross-platform tarball bundling all three binaries.

## Release flow (as configured)

```
feature/* ──PR──▶ develop          (default branch, integration)
develop ──PR merge──▶ main          (release-only; guard enforces develop-only)
                     │  push to main → release-plz release-pr
                     ▼
        release-plz-* PR (version bump + CHANGELOG) ──▶ main
                     │  merge of that PR → release-plz release
                     ▼
        tag openflows-X.Y.Z + single GitHub Release (no `v`)
                     ▼
        release-assets → attach openflows-<X.Y.Z>-<target>.tar.gz
                         (bundles openflows, openflows-doctor, openflows-harness)
```