### PR TITLE
feat(config): centralize environment configuration with envconfig

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,89 +1,53 @@
 # ──────────────────────────────────────────────────────────────────────────
 # OpenFlows — Environment Configuration
 # ──────────────────────────────────────────────────────────────────────────
-# Copy this to .env and fill in your values. The startup script will
-# automatically load these when you run: ./scripts/start.sh
+# Copy this to .env and fill in your values.
 
 # ── GitHub (REQUIRED) ─────────────────────────────────────────────────────
-# Get your GitHub personal access token:
-#   1. https://github.com/settings/tokens
-#   2. Click "Generate new token" → "Generate new token (classic)"
-#   3. Select scope: repo (all options)
-#   4. Copy the token below
+# Get it from https://github.com/settings/tokens (classic, scope: repo).
 GITHUB_TOKEN=ghp_your_token_here
 
-# The GitHub repository to work on (e.g., my-org/my-repo)
+# Target repository to work on (e.g., my-org/my-repo).
 GITHUB_REPOSITORY=owner/repo
 
 # ── Coder (REQUIRED) ──────────────────────────────────────────────────────
-# CODER_SESSION_TOKEN — Used for API authentication to provision workspaces
-# and manage chats. This is YOUR personal session token, granting your
-# permissions for workspace creation, chat management, and status monitoring.
-#
-# WHERE TO GET IT:
-# http://localhost:7080/settings/tokens/new
+# Personal session token from http://localhost:7080/settings/tokens/new.
 CODER_SESSION_TOKEN=your_token_here
 
 # ── Admin user (optional overrides) ─────────────────────────────────────
-# Override the defaults used when bootstrap creates the Coder admin account.
-# Defaults: admin / admin@openflows.dev / Op3nFl0ws!
-# CODER_ADMIN_USERNAME=admin
+# Defaults apply if unset: admin@openflows.dev / Op3nFl0ws!
 # CODER_ADMIN_EMAIL=admin@openflows.dev
 # CODER_ADMIN_PASSWORD=Op3nFl0ws!
 
 # ── Coder GitHub sign-ups ─────────────────────────────────────────────────
-# Coder ships with a default Coder-managed GitHub app (device flow) so users
-# can sign in with GitHub out of the box — no OAuth app setup needed.
-# Sign-ups are enabled by default. To disable:
+# Sign-ups are enabled by default; set false to disable.
 # CODER_OAUTH2_GITHUB_ALLOW_SIGNUPS=false
 
 # ── Coder GitHub external auth (Git App) ───────────────────────────────────
-# Lets users authenticate a GitHub App in Coder and lets agents push/pull
-# against private repos. This is a SEPARATE OAuth app from the login app above
-# and is used for git operations (not signing in to Coder).
-#
-# To set up:
-#   1. Create a GitHub App: https://github.com/settings/apps/new
-#   2. Set the authorization callback URL to:
-#        ${CODER_ACCESS_URL}/external-auth/primary-github/callback
-#      where `primary-github` matches CODER_EXTERNAL_AUTH_0_ID below.
-#   3. Deactivate webhooks. Grant permissions (Contents, Pull requests,
-#      Workflows = Read & Write; Metadata = Read-only).
-#   4. In the app's Advanced tab, select "Make this GitHub App public".
-#   5. Install the app for your org/account and allow appropriate repos.
-#
-# Set the ID, type, client ID, and client secret:
+# Set these to let agents push/pull against private repos.
 # CODER_EXTERNAL_AUTH_0_ID=primary-github
 # CODER_EXTERNAL_AUTH_0_TYPE=github
 # CODER_EXTERNAL_AUTH_0_CLIENT_ID=your_github_app_client_id
 # CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=your_github_app_client_secret
-#
-# 'repo' grants full read/write so workspaces can push. Add scopes as needed.
 # CODER_EXTERNAL_AUTH_0_SCOPES=repo
-#
-# Surface the "Install GitHub App" button in the Coder UI so users can install
-# the app on their account/org (required to link private repos). Replace the
-# slug with your app's slug:
-# CODER_EXTERNAL_AUTH_0_APP_INSTALL_URL=https://github.com/apps/<your-app-slug>/installations/new
 
 # ── Infrastructure ────────────────────────────────────────────────────────
-# By default the CLI connects to the local docker-compose stack (Redis on port
-# 6379, Coder on port 7080), so `docker compose up -d` works out of the box.
-# Only set these if you host Redis or Coder elsewhere:
-# e.g. if you run Redis in the cloud, set REDIS_URL to that instance.
+# Only set if you host Redis or Coder elsewhere than the local stack.
 # REDIS_URL=redis://localhost:6379
 # CODER_URL=http://localhost:7080
 
-# Uncomment and adjust only if you changed the ports/services in docker-compose
-# CODER_PORT=7080
-# CODER_INTERNAL_PORT=7080
-# CODER_PG_PASSWORD=coder
-
 # ── Tenant ────────────────────────────────────────────────────────────────
-# Namespace for Redis keys and workspace isolation
+# Namespace for Redis keys and workspace isolation.
 OPENFLOWS_TENANT=default
 
-# ── Optional: Notifications ────────────────────────────────────────────────
-# Send escalation notifications to Slack or Discord when human intervention needed
-# SLACK_WEBHOOK_URL=https://hooks.slack.com/services/your/webhook/url
-# DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/your/webhook/url
+# ── Centralized defaults (do not set) ─────────────────────────────────────
+# Applied by config::env unless overridden:
+#   CODER_URL=http://localhost:7080
+#   CODER_IMAGE_TAG=latest
+#   CODER_ADMIN_EMAIL=admin@openflows.dev
+#   CODER_ADMIN_PASSWORD=Op3nFl0ws!
+#   REDIS_URL=redis://localhost:6379
+#   A2A_RELAY_ADDR=127.0.0.1:3000
+#   OPENFLOWS_TENANT=default
+#   OPENFLOWS_TAR=tar
+#   USE_AI_GATEWAY=false

--- a/.env.example
+++ b/.env.example
@@ -25,10 +25,14 @@ CODER_SESSION_TOKEN=your_token_here
 # CODER_ADMIN_EMAIL=admin@openflows.dev
 # CODER_ADMIN_PASSWORD=your_secure_password_here
 
-# ── Coder GitHub external auth (Git App) ───────────────────────────────────
-# Set these to let agents push/pull against private repos.
+# ── Coder GitHub external auth (OIDC / Git App) ───────────────────────────
+# Set these to allow agents authenticate via OIDC.
+# CODER_EXTERNAL_AUTH_0_ID=primary-github
+# CODER_EXTERNAL_AUTH_0_TYPE=github
 # CODER_EXTERNAL_AUTH_0_CLIENT_ID=your_github_app_client_id
 # CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=your_github_app_client_secret
+# CODER_EXTERNAL_AUTH_0_SCOPES=repo
+# CODER_EXTERNAL_AUTH_0_APP_INSTALL_URL=https://github.com/apps/<your-app-slug>/installations/new
 
 # ── Infrastructure ────────────────────────────────────────────────────────
 # Only set if you host Redis or Coder elsewhere than the local stack.

--- a/.env.example
+++ b/.env.example
@@ -10,26 +10,25 @@ GITHUB_TOKEN=ghp_your_token_here
 # Target repository to work on (e.g., my-org/my-repo).
 GITHUB_REPOSITORY=owner/repo
 
+# GitHub REST API base. Only set for a self-hosted GitHub Enterprise or a
+# Gitea-compatible instance; defaults to https://api.github.com.
+# GITHUB_API_BASE=https://api.github.com
+
 # ── Coder (REQUIRED) ──────────────────────────────────────────────────────
 # Personal session token from http://localhost:7080/settings/tokens/new.
 CODER_SESSION_TOKEN=your_token_here
 
 # ── Admin user (optional overrides) ─────────────────────────────────────
-# Defaults apply if unset: admin@openflows.dev / Op3nFl0ws!
+# Email defaults to admin@openflows.dev if unset. There is no baked-in
+# password default — the bootstrapper applies a secure fallback only when
+# none is supplied.
 # CODER_ADMIN_EMAIL=admin@openflows.dev
-# CODER_ADMIN_PASSWORD=Op3nFl0ws!
-
-# ── Coder GitHub sign-ups ─────────────────────────────────────────────────
-# Sign-ups are enabled by default; set false to disable.
-# CODER_OAUTH2_GITHUB_ALLOW_SIGNUPS=false
+# CODER_ADMIN_PASSWORD=your_secure_password_here
 
 # ── Coder GitHub external auth (Git App) ───────────────────────────────────
 # Set these to let agents push/pull against private repos.
-# CODER_EXTERNAL_AUTH_0_ID=primary-github
-# CODER_EXTERNAL_AUTH_0_TYPE=github
 # CODER_EXTERNAL_AUTH_0_CLIENT_ID=your_github_app_client_id
 # CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=your_github_app_client_secret
-# CODER_EXTERNAL_AUTH_0_SCOPES=repo
 
 # ── Infrastructure ────────────────────────────────────────────────────────
 # Only set if you host Redis or Coder elsewhere than the local stack.
@@ -45,9 +44,10 @@ OPENFLOWS_TENANT=default
 #   CODER_URL=http://localhost:7080
 #   CODER_IMAGE_TAG=latest
 #   CODER_ADMIN_EMAIL=admin@openflows.dev
-#   CODER_ADMIN_PASSWORD=Op3nFl0ws!
+#   CODER_ADMIN_USERNAME=admin
 #   REDIS_URL=redis://localhost:6379
 #   A2A_RELAY_ADDR=127.0.0.1:3000
 #   OPENFLOWS_TENANT=default
 #   OPENFLOWS_TAR=tar
+#   GITHUB_API_BASE=https://api.github.com
 #   USE_AI_GATEWAY=false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -168,7 +168,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -421,7 +421,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -429,6 +429,7 @@ name = "config"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "envconfig",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -514,6 +515,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "envconfig"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2934d78aeb06e54961db5b96cfca2b01f5cb01cf11c34f7b088932fd48233ac6"
+dependencies = [
+ "envconfig_derive",
+]
+
+[[package]]
+name = "envconfig_derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "452c458dfb890a2fea64e4c894f83daad61689fb9bbe84c382e1ce6d7536710b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,7 +547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -901,7 +922,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1253,7 +1274,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1439,7 +1460,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror",
  "tokio",
  "tracing",
@@ -1476,7 +1497,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1684,7 +1705,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1916,7 +1937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1978,7 +1999,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64",
+ "config",
+ "envconfig",
  "futures",
  "futures-util",
  "reqwest",
@@ -772,6 +774,7 @@ name = "github"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "config",
  "pocketflow-core",
  "rand 0.8.6",
  "regex",
@@ -1387,6 +1390,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "config",
  "fred",
  "futures",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # CLI / env
 dotenvy    = "0.15"
 
+# env config
+envconfig = "0.11"
+
 # yaml
 serde_yaml = "0.9"
 

--- a/binary/src/bin/agentflow.rs
+++ b/binary/src/bin/agentflow.rs
@@ -149,8 +149,8 @@ async fn run_controller() -> Result<()> {
     cfg.validate_controller()?;
     let coder_url = cfg.coder.url.clone();
     let _coder_token = cfg.coder.effective_token();
-    let redis_url = cfg.infra.redis_url.clone();
-    let tenant = cfg.tenant.tenant.clone();
+    let redis_url = cfg.infra.effective_redis_url();
+    let tenant = cfg.tenant.effective_tenant().to_string();
     let github_repo = cfg
         .github
         .repository

--- a/binary/src/bin/agentflow.rs
+++ b/binary/src/bin/agentflow.rs
@@ -374,8 +374,7 @@ async fn run_tenant_clean(action: &TenantCommands) -> Result<()> {
         unreachable!("run_tenant_clean called with non-clean action");
     };
 
-    let redis_url =
-        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+    let redis_url = config::EnvConfig::from_env()?.infra.effective_redis_url();
     // Scope the store to the tenant we are cleaning: SharedStore namespaces
     // every key as `ns:{tenant}:{key}`, so we pass it the tenant and use plain
     // keys below. (We must NOT also hand-format `ns:{name}:` prefixes here,
@@ -490,8 +489,7 @@ async fn run_tenant(action: TenantCommands) -> Result<()> {
         TenantCommands::List => {
             println!("Tenants (from Redis namespaces):");
             // Read all ns:* keys from Redis and list unique tenants
-            let redis_url =
-                std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+            let redis_url = config::EnvConfig::from_env()?.infra.effective_redis_url();
             match pocketflow_core::SharedStore::new_redis(&redis_url).await {
                 Ok(store) => {
                     // raw_keys scans full Redis keys (`ns:*`) without re-applying
@@ -522,8 +520,7 @@ async fn run_tenant(action: TenantCommands) -> Result<()> {
             println!("Removing tenant '{}'...", name);
 
             if purge {
-                let redis_url = std::env::var("REDIS_URL")
-                    .unwrap_or_else(|_| "redis://localhost:6379".to_string());
+                let redis_url = config::EnvConfig::from_env()?.infra.effective_redis_url();
                 match pocketflow_core::SharedStore::new_redis(&redis_url).await {
                     Ok(store) => {
                         // raw_keys + raw_del operate on full keys, so we purge the
@@ -555,8 +552,7 @@ async fn run_tenant(action: TenantCommands) -> Result<()> {
 }
 
 async fn run_status(tenant: Option<String>, json: bool) -> Result<()> {
-    let redis_url =
-        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+    let redis_url = config::EnvConfig::from_env()?.infra.effective_redis_url();
 
     // raw_keys scans full Redis keys without namespacing, so we can enumerate
     // all `ns:{tenant}:` namespaces from a single store.
@@ -642,8 +638,7 @@ async fn run_status(tenant: Option<String>, json: bool) -> Result<()> {
 async fn run_gate(action: GateCommands) -> Result<()> {
     use openflows_harness::Harness;
 
-    let redis_url =
-        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+    let redis_url = config::EnvConfig::from_env()?.infra.effective_redis_url();
 
     match action {
         GateCommands::Approve {

--- a/binary/src/bin/agentflow.rs
+++ b/binary/src/bin/agentflow.rs
@@ -145,17 +145,16 @@ async fn main() -> Result<()> {
 }
 
 async fn run_controller() -> Result<()> {
-    // ── Fail-fast environment validation ────────────────────────────────
-    let coder_url =
-        std::env::var("CODER_URL").unwrap_or_else(|_| "http://localhost:7080".to_string());
-    let _coder_token = std::env::var("CODER_SESSION_TOKEN")
-        .context("CODER_SESSION_TOKEN is not set. The Controller must run inside an openflows-nexus workspace.")?;
-    let redis_url =
-        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
-    let tenant = std::env::var("OPENFLOWS_TENANT").context(
-        "OPENFLOWS_TENANT is not set. The Controller must run inside an openflows-nexus workspace.",
-    )?;
-    let github_repo = std::env::var("GITHUB_REPOSITORY")
+    let cfg = config::EnvConfig::from_env().context("failed to load environment configuration")?;
+    cfg.validate_controller()?;
+    let coder_url = cfg.coder.url.clone();
+    let _coder_token = cfg.coder.effective_token();
+    let redis_url = cfg.infra.redis_url.clone();
+    let tenant = cfg.tenant.tenant.clone();
+    let github_repo = cfg
+        .github
+        .repository
+        .clone()
         .context("GITHUB_REPOSITORY is not set. The Controller must run inside an openflows-nexus workspace.")?;
 
     tracing::info!(

--- a/binary/src/debug.rs
+++ b/binary/src/debug.rs
@@ -1,5 +1,6 @@
 use crate::state::{Ticket, WorkerSlot, KEY_TICKETS, KEY_WORKER_SLOTS};
 use anyhow::Result;
+use config::Envconfig;
 use pocketflow_core::SharedStore;
 use std::collections::HashMap;
 
@@ -7,7 +8,7 @@ pub async fn debug_system() -> Result<()> {
     println!("=== AgentFlow Debug Info ===");
 
     // Check Redis / Store
-    let store = if let Ok(url) = std::env::var("REDIS_URL") {
+    let store = if let Some(url) = config::InfraConfig::init_from_env()?.redis_url {
         println!("Store: Redis ({})", url);
         SharedStore::new_redis(&url).await?
     } else {

--- a/binary/src/doctor.rs
+++ b/binary/src/doctor.rs
@@ -2,6 +2,7 @@
 //! Diagnostic checks shared by `openflows doctor` and `openflows-doctor`.
 
 use anyhow::Result;
+use config::Envconfig;
 
 pub async fn run_checks() -> Result<()> {
     let mut all_pass = true;
@@ -10,8 +11,7 @@ pub async fn run_checks() -> Result<()> {
     println!();
 
     // 1. Coder server reachable
-    let coder_url =
-        std::env::var("CODER_URL").unwrap_or_else(|_| "http://localhost:7080".to_string());
+    let coder_url = config::CoderConfig::init_from_env()?.url;
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
         .build()?;
@@ -43,13 +43,14 @@ pub async fn run_checks() -> Result<()> {
     }
 
     // 2. Coder image tag
-    let tag = std::env::var("CODER_IMAGE_TAG").unwrap_or_else(|_| "latest".to_string());
+    let tag = config::CoderConfig::init_from_env()?.image_tag;
     println!("  ℹ Coder image tag: {} (pin for production)", tag);
 
     // 3. LLM provider/model configured
     {
-        let token = std::env::var("CODER_SESSION_TOKEN")
-            .or_else(|_| std::env::var("CODER_API_TOKEN"))
+        let token = config::CoderConfig::init_from_env()?
+            .session_token
+            .or(std::env::var("CODER_API_TOKEN").ok())
             .unwrap_or_default();
         if !token.is_empty() {
             let client = reqwest::Client::builder()
@@ -108,8 +109,7 @@ pub async fn run_checks() -> Result<()> {
     }
 
     // 5. Redis reachable
-    let redis_url =
-        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+    let redis_url = config::InfraConfig::init_from_env()?.effective_redis_url();
     match pocketflow_core::SharedStore::new_redis(&redis_url).await {
         Ok(_) => println!("  ✓ Redis SharedStore reachable at {}", redis_url),
         Err(e) => {

--- a/binary/src/orchestration.rs
+++ b/binary/src/orchestration.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use config::Envconfig;
 use tracing::{info, warn};
 
 use crate::bundled::bundled_files;
@@ -17,11 +18,8 @@ pub struct OrchestrationResolver {
 
 impl OrchestrationResolver {
     pub fn new() -> Result<Self> {
-        let openflows_home = std::env::var("OPENFLOWS_HOME")
-            .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
-            .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
-            .ok();
-        let openflows_home_path = openflows_home.map(std::path::PathBuf::from);
+        let tenant = config::TenantConfig::init_from_env()?;
+        let openflows_home_path = Some(tenant.openflows_home());
 
         let mut candidates: Vec<std::path::PathBuf> = Vec::new();
 
@@ -66,15 +64,7 @@ impl OrchestrationResolver {
                 }
             })
             .unwrap_or_else(|| {
-                let home = openflows_home_path.unwrap_or_else(|| {
-                    let home = std::env::var("OPENFLOWS_HOME")
-                        .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
-                        .or_else(|_| {
-                            std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h))
-                        })
-                        .unwrap_or_else(|_| ".openflows".to_string());
-                    std::path::PathBuf::from(home)
-                });
+                let home = tenant.openflows_home();
                 (home, false)
             });
 

--- a/crates/agent-forge/src/lib.rs
+++ b/crates/agent-forge/src/lib.rs
@@ -12,7 +12,7 @@ use config::{
         full_ticket_key, full_ticket_key_flat, KEY_PENDING_PRS, KEY_TICKETS, KEY_TICKET_CHAT,
         KEY_TICKET_CHAT_ACTION, KEY_TICKET_STATUS, KEY_WORKER_SLOTS,
     },
-    Ticket, TicketStatus, WorkerSlot, ACTION_FAILED, ACTION_PR_OPENED,
+    Ticket, TicketStatus, WorkerSlot, ACTION_FAILED, ACTION_PR_OPENED, Envconfig,
 };
 use pocketflow_core::{node::PAUSE_SIGNAL, Action, BatchNode, SharedStore};
 use serde::{Deserialize, Serialize};
@@ -73,12 +73,13 @@ impl ForgePairNode {
     }
 
     async fn coder_client_from_store(store: &SharedStore) -> Option<CoderClient> {
+        let coder = config::CoderConfig::init_from_env().ok();
         let coder_url: Option<String> = store
             .get_typed("coder_url")
             .await
-            .or_else(|| std::env::var("CODER_URL").ok());
-        let coder_token: Option<String> = std::env::var("CODER_SESSION_TOKEN")
-            .ok()
+            .or_else(|| coder.as_ref().map(|c| c.url.clone()));
+        let coder_token: Option<String> = coder
+            .and_then(|c| c.session_token)
             .or_else(|| std::env::var("CODER_API_TOKEN").ok());
         let coder_token = if coder_token.as_deref().is_some_and(|t| !t.is_empty()) {
             coder_token

--- a/crates/agent-forge/src/lib.rs
+++ b/crates/agent-forge/src/lib.rs
@@ -12,7 +12,7 @@ use config::{
         full_ticket_key, full_ticket_key_flat, KEY_PENDING_PRS, KEY_TICKETS, KEY_TICKET_CHAT,
         KEY_TICKET_CHAT_ACTION, KEY_TICKET_STATUS, KEY_WORKER_SLOTS,
     },
-    Ticket, TicketStatus, WorkerSlot, ACTION_FAILED, ACTION_PR_OPENED, Envconfig,
+    Envconfig, Ticket, TicketStatus, WorkerSlot, ACTION_FAILED, ACTION_PR_OPENED,
 };
 use pocketflow_core::{node::PAUSE_SIGNAL, Action, BatchNode, SharedStore};
 use serde::{Deserialize, Serialize};

--- a/crates/agent-lore/src/types.rs
+++ b/crates/agent-lore/src/types.rs
@@ -54,12 +54,7 @@ impl LoreConfig {
         let registry = Registry::load(registry_path)?;
         let github_token = registry.resolve_github_token("lore")?;
 
-        let env = config::EnvConfig::from_env().ok();
-        let workspace_root = env
-            .as_ref()
-            .and_then(|e| e.agent.effective_workspace_root())
-            .map(std::path::PathBuf::from)
-            .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+        let workspace_root = env_workspace_root();
         let persona_path = workspace_root
             .join("orchestration")
             .join("agent")
@@ -76,11 +71,7 @@ impl LoreConfig {
 
     pub fn from_env() -> Self {
         let env = config::EnvConfig::from_env().ok();
-        let workspace_root = env
-            .as_ref()
-            .and_then(|e| e.agent.effective_workspace_root())
-            .map(std::path::PathBuf::from)
-            .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+        let workspace_root = env_workspace_root();
         let persona_path = workspace_root
             .join("orchestration")
             .join("agent")
@@ -130,6 +121,17 @@ impl LoreConfig {
             github_token,
         }
     }
+}
+
+/// Resolve the effective workspace root from the centralized config, falling
+/// back to the current directory. Shared by the config constructors so the
+/// resolution logic is defined once.
+fn env_workspace_root() -> std::path::PathBuf {
+    config::EnvConfig::from_env()
+        .ok()
+        .and_then(|e| e.agent.effective_workspace_root())
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_default())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/agent-lore/src/types.rs
+++ b/crates/agent-lore/src/types.rs
@@ -54,9 +54,12 @@ impl LoreConfig {
         let registry = Registry::load(registry_path)?;
         let github_token = registry.resolve_github_token("lore")?;
 
-        let workspace_root = std::env::var("AGENTFLOW_WORKSPACE_ROOT")
+        let env = config::EnvConfig::from_env().ok();
+        let workspace_root = env
+            .as_ref()
+            .and_then(|e| e.agent.effective_workspace_root())
             .map(std::path::PathBuf::from)
-            .unwrap_or_else(|_| std::env::current_dir().unwrap_or_default());
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
         let persona_path = workspace_root
             .join("orchestration")
             .join("agent")
@@ -72,9 +75,12 @@ impl LoreConfig {
     }
 
     pub fn from_env() -> Self {
-        let workspace_root = std::env::var("AGENTFLOW_WORKSPACE_ROOT")
+        let env = config::EnvConfig::from_env().ok();
+        let workspace_root = env
+            .as_ref()
+            .and_then(|e| e.agent.effective_workspace_root())
             .map(std::path::PathBuf::from)
-            .unwrap_or_else(|_| std::env::current_dir().unwrap_or_default());
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
         let persona_path = workspace_root
             .join("orchestration")
             .join("agent")
@@ -102,13 +108,17 @@ impl LoreConfig {
                     }
                     Err(e) => {
                         tracing::warn!(error = %e, registry = %path.display(), "LORE failed to resolve token from registry, falling back");
-                        std::env::var("GITHUB_TOKEN").unwrap_or_default()
+                        env.as_ref()
+                            .and_then(|e| e.github.token.clone())
+                            .unwrap_or_default()
                     }
                 }
             }
             _ => {
                 tracing::warn!("LORE: registry.json not found, falling back to GITHUB_TOKEN");
-                std::env::var("GITHUB_TOKEN").unwrap_or_default()
+                env.as_ref()
+                    .and_then(|e| e.github.token.clone())
+                    .unwrap_or_default()
             }
         };
 

--- a/crates/agent-nexus/src/a2a/mod.rs
+++ b/crates/agent-nexus/src/a2a/mod.rs
@@ -40,7 +40,9 @@ pub async fn start_a2a_relay(store: Arc<SharedStore>) -> Result<Arc<A2ARelay>> {
     let relay = Arc::new(A2ARelay::new(store));
     let router = create_router(relay.clone());
 
-    let addr = std::env::var("A2A_RELAY_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
+    let addr = config::EnvConfig::from_env()
+        .map(|c| c.infra.a2a_relay_addr)
+        .unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     info!(
         addr = %addr,

--- a/crates/agent-nexus/src/lib.rs
+++ b/crates/agent-nexus/src/lib.rs
@@ -278,14 +278,20 @@ impl NexusNode {
 
         let tenant = config::EnvConfig::from_env().ok();
 
-        if let Some(path) = tenant.as_ref().and_then(|t| t.tenant.registry_path.as_deref()) {
+        if let Some(path) = tenant
+            .as_ref()
+            .and_then(|t| t.tenant.registry_path.as_deref())
+        {
             let path = PathBuf::from(path);
             if path.exists() {
                 return Registry::load(path);
             }
         }
 
-        if let Some(content) = tenant.as_ref().and_then(|t| t.tenant.registry_json.as_deref()) {
+        if let Some(content) = tenant
+            .as_ref()
+            .and_then(|t| t.tenant.registry_json.as_deref())
+        {
             let registry: Registry =
                 serde_json::from_str(content).context("Failed to parse OPENFLOWS_REGISTRY_JSON")?;
             return Ok(registry);
@@ -352,7 +358,10 @@ Before significant work, read the relevant skill file to understand the workflow
         let token = match self.resolve_github_token() {
             Ok(t) if !t.is_empty() => t,
             Ok(_) | Err(_) => {
-                match config::EnvConfig::from_env().ok().and_then(|e| e.github.token) {
+                match config::EnvConfig::from_env()
+                    .ok()
+                    .and_then(|e| e.github.token)
+                {
                     Some(t) if !t.is_empty() => t,
                     _ => match std::fs::read_to_string("/tmp/github_token") {
                         Ok(t) if !t.trim().is_empty() => t.trim().to_string(),
@@ -424,7 +433,10 @@ Before significant work, read the relevant skill file to understand the workflow
 
         let token = match self.resolve_github_token() {
             Ok(t) => t,
-            Err(_) => match config::EnvConfig::from_env().ok().and_then(|e| e.github.token) {
+            Err(_) => match config::EnvConfig::from_env()
+                .ok()
+                .and_then(|e| e.github.token)
+            {
                 Some(t) if !t.is_empty() => {
                     info!("Using GITHUB_TOKEN env var for PR sync");
                     t
@@ -2459,7 +2471,10 @@ Use `openflows-harness` for all coordination:
 
         let token = match self.resolve_github_token() {
             Ok(t) if !t.is_empty() => t,
-            Ok(_) | Err(_) => match config::EnvConfig::from_env().ok().and_then(|e| e.github.token) {
+            Ok(_) | Err(_) => match config::EnvConfig::from_env()
+                .ok()
+                .and_then(|e| e.github.token)
+            {
                 Some(t) if !t.is_empty() => t,
                 _ => match std::fs::read_to_string("/tmp/github_token") {
                     Ok(t) if !t.trim().is_empty() => t.trim().to_string(),
@@ -3769,15 +3784,17 @@ impl Node for NexusNode {
             warn!("Failed to sync registry: {}", e);
         }
 
-        let repository =
-            match config::EnvConfig::from_env().ok().and_then(|e| e.github.repository) {
-                Some(repo) => repo,
-                None => store
-                    .get("repository")
-                    .await
-                    .and_then(|v| v.as_str().map(String::from))
-                    .unwrap_or_default(),
-            };
+        let repository = match config::EnvConfig::from_env()
+            .ok()
+            .and_then(|e| e.github.repository)
+        {
+            Some(repo) => repo,
+            None => store
+                .get("repository")
+                .await
+                .and_then(|v| v.as_str().map(String::from))
+                .unwrap_or_default(),
+        };
 
         // Store repository in Redis so workspace provisioning can use it
         if !repository.is_empty() {

--- a/crates/agent-nexus/src/lib.rs
+++ b/crates/agent-nexus/src/lib.rs
@@ -276,16 +276,18 @@ impl NexusNode {
             return Registry::load(&self.registry_path);
         }
 
-        if let Ok(path) = std::env::var("OPENFLOWS_REGISTRY_PATH") {
+        let tenant = config::EnvConfig::from_env().ok();
+
+        if let Some(path) = tenant.as_ref().and_then(|t| t.tenant.registry_path.as_deref()) {
             let path = PathBuf::from(path);
             if path.exists() {
                 return Registry::load(path);
             }
         }
 
-        if let Ok(content) = std::env::var("OPENFLOWS_REGISTRY_JSON") {
-            let registry: Registry = serde_json::from_str(&content)
-                .context("Failed to parse OPENFLOWS_REGISTRY_JSON")?;
+        if let Some(content) = tenant.as_ref().and_then(|t| t.tenant.registry_json.as_deref()) {
+            let registry: Registry =
+                serde_json::from_str(content).context("Failed to parse OPENFLOWS_REGISTRY_JSON")?;
             return Ok(registry);
         }
 
@@ -311,7 +313,10 @@ impl NexusNode {
     fn load_skills_for_role(&self, role: &str) -> String {
         let mut skills = Vec::new();
 
-        if let Ok(reg_json) = std::env::var("OPENFLOWS_REGISTRY_JSON") {
+        if let Some(reg_json) = config::EnvConfig::from_env()
+            .ok()
+            .and_then(|e| e.tenant.registry_json)
+        {
             if let Ok(registry) = serde_json::from_str::<config::Registry>(&reg_json) {
                 if let Some(entry) = registry.get(role) {
                     for skill_name in &entry.skills {
@@ -346,16 +351,18 @@ Before significant work, read the relevant skill file to understand the workflow
 
         let token = match self.resolve_github_token() {
             Ok(t) if !t.is_empty() => t,
-            Ok(_) | Err(_) => match std::env::var("GITHUB_TOKEN") {
-                Ok(t) if !t.is_empty() => t,
-                Ok(_) | Err(_) => match std::fs::read_to_string("/tmp/github_token") {
-                    Ok(t) if !t.trim().is_empty() => t.trim().to_string(),
-                    Ok(_) | Err(_) => {
-                        warn!("GitHub token not configured, skipping issue sync");
-                        return Ok(());
-                    }
-                },
-            },
+            Ok(_) | Err(_) => {
+                match config::EnvConfig::from_env().ok().and_then(|e| e.github.token) {
+                    Some(t) if !t.is_empty() => t,
+                    _ => match std::fs::read_to_string("/tmp/github_token") {
+                        Ok(t) if !t.trim().is_empty() => t.trim().to_string(),
+                        Ok(_) | Err(_) => {
+                            warn!("GitHub token not configured, skipping issue sync");
+                            return Ok(());
+                        }
+                    },
+                }
+            }
         };
 
         let client = github::GithubRestClient::new(&token);
@@ -417,12 +424,12 @@ Before significant work, read the relevant skill file to understand the workflow
 
         let token = match self.resolve_github_token() {
             Ok(t) => t,
-            Err(_) => match std::env::var("GITHUB_TOKEN") {
-                Ok(t) if !t.is_empty() => {
+            Err(_) => match config::EnvConfig::from_env().ok().and_then(|e| e.github.token) {
+                Some(t) if !t.is_empty() => {
                     info!("Using GITHUB_TOKEN env var for PR sync");
                     t
                 }
-                Ok(_) | Err(_) => match std::fs::read_to_string("/tmp/github_token") {
+                _ => match std::fs::read_to_string("/tmp/github_token") {
                     Ok(t) if !t.trim().is_empty() => {
                         info!("Using /tmp/github_token file for PR sync");
                         t.trim().to_string()
@@ -740,12 +747,13 @@ Before significant work, read the relevant skill file to understand the workflow
     }
 
     async fn coder_client_from_store(store: &SharedStore) -> Option<CoderClient> {
+        let coder_cfg = config::EnvConfig::from_env().ok();
         let coder_url: Option<String> = store
             .get_typed("coder_url")
             .await
-            .or_else(|| std::env::var("CODER_URL").ok());
-        let coder_token: Option<String> = std::env::var("CODER_SESSION_TOKEN")
-            .ok()
+            .or_else(|| coder_cfg.as_ref().map(|e| e.coder.url.clone()));
+        let coder_token: Option<String> = coder_cfg
+            .and_then(|e| e.coder.session_token)
             .or_else(|| std::env::var("CODER_API_TOKEN").ok());
         let coder_token = if coder_token.as_deref().is_some_and(|t| !t.is_empty()) {
             coder_token
@@ -876,8 +884,14 @@ Before significant work, read the relevant skill file to understand the workflow
                 "role": worker_id,
                 "ticket_id": ticket_id,
                 "redis_url": "redis://redis:6379",
-                "tenant": std::env::var("OPENFLOWS_TENANT").unwrap_or_else(|_| "default".to_string()),
-                "coder_url": coder_url.unwrap_or_else(|| std::env::var("CODER_URL").unwrap_or_default()),
+                "tenant": config::EnvConfig::from_env()
+                    .map(|e| e.tenant.effective_tenant().to_string())
+                    .unwrap_or_else(|_| "default".to_string()),
+                "coder_url": coder_url.unwrap_or_else(|| {
+                    config::EnvConfig::from_env()
+                        .map(|e| e.coder.url)
+                        .unwrap_or_default()
+                }),
             }),
         };
         // Inject the Terraform variable the template reads.
@@ -1311,7 +1325,9 @@ Before significant work, read the relevant skill file to understand the workflow
         // when the hook rewrites or overrides initial prompts.
         // The hook's stdout becomes the session context automatically in Claude Code.
         use coder_client::types::{build_chat_labels, CreateChatRequest};
-        let tenant = std::env::var("OPENFLOWS_TENANT").unwrap_or_else(|_| "default".to_string());
+        let tenant = config::EnvConfig::from_env()
+            .map(|e| e.tenant.effective_tenant().to_string())
+            .unwrap_or_else(|_| "default".to_string());
         let labels = build_chat_labels(ticket_id, role, "openflows", &tenant);
 
         // Resolve the default organization ID required by the Coder chats API.
@@ -2443,9 +2459,9 @@ Use `openflows-harness` for all coordination:
 
         let token = match self.resolve_github_token() {
             Ok(t) if !t.is_empty() => t,
-            Ok(_) | Err(_) => match std::env::var("GITHUB_TOKEN") {
-                Ok(t) if !t.is_empty() => t,
-                Ok(_) | Err(_) => match std::fs::read_to_string("/tmp/github_token") {
+            Ok(_) | Err(_) => match config::EnvConfig::from_env().ok().and_then(|e| e.github.token) {
+                Some(t) if !t.is_empty() => t,
+                _ => match std::fs::read_to_string("/tmp/github_token") {
                     Ok(t) if !t.trim().is_empty() => t.trim().to_string(),
                     Ok(_) | Err(_) => {
                         warn!("GitHub token not configured, assuming CI is ready");
@@ -2479,7 +2495,10 @@ Use `openflows-harness` for all coordination:
     /// Checks common workspace locations like ~/Sandbox/{repo_name}
     fn detect_workspace_path(_owner: &str, repo_name: &str) -> std::path::PathBuf {
         // Check for WORKSPACE_ROOT environment variable first
-        if let Ok(workspace_root) = std::env::var("WORKSPACE_ROOT") {
+        if let Some(workspace_root) = config::EnvConfig::from_env()
+            .ok()
+            .and_then(|e| e.agent.effective_workspace_root())
+        {
             let path = std::path::PathBuf::from(workspace_root).join(repo_name);
             if path.exists() {
                 return path;
@@ -3750,15 +3769,15 @@ impl Node for NexusNode {
             warn!("Failed to sync registry: {}", e);
         }
 
-        let repository = if let Ok(repo) = std::env::var("GITHUB_REPOSITORY") {
-            repo
-        } else {
-            store
-                .get("repository")
-                .await
-                .and_then(|v| v.as_str().map(String::from))
-                .unwrap_or_default()
-        };
+        let repository =
+            match config::EnvConfig::from_env().ok().and_then(|e| e.github.repository) {
+                Some(repo) => repo,
+                None => store
+                    .get("repository")
+                    .await
+                    .and_then(|v| v.as_str().map(String::from))
+                    .unwrap_or_default(),
+            };
 
         // Store repository in Redis so workspace provisioning can use it
         if !repository.is_empty() {

--- a/crates/agent-nexus/src/lib.rs
+++ b/crates/agent-nexus/src/lib.rs
@@ -271,6 +271,22 @@ impl NexusNode {
         registry.resolve_github_token("nexus")
     }
 
+    /// Best-effort GitHub token from the centralized config (`GITHUB_TOKEN`),
+    /// falling back to the `/tmp/github_token` file. Returns `None` when
+    /// neither is available so callers can decide how to degrade.
+    fn resolve_github_token_from_env_or_file(&self) -> Option<String> {
+        config::EnvConfig::from_env()
+            .ok()
+            .and_then(|e| e.github.token)
+            .filter(|t| !t.is_empty())
+            .or_else(|| {
+                std::fs::read_to_string("/tmp/github_token")
+                    .ok()
+                    .map(|t| t.trim().to_string())
+                    .filter(|t| !t.is_empty())
+            })
+    }
+
     fn load_registry(&self) -> Result<Registry> {
         if self.registry_path.exists() {
             return Registry::load(&self.registry_path);
@@ -357,21 +373,13 @@ Before significant work, read the relevant skill file to understand the workflow
 
         let token = match self.resolve_github_token() {
             Ok(t) if !t.is_empty() => t,
-            Ok(_) | Err(_) => {
-                match config::EnvConfig::from_env()
-                    .ok()
-                    .and_then(|e| e.github.token)
-                {
-                    Some(t) if !t.is_empty() => t,
-                    _ => match std::fs::read_to_string("/tmp/github_token") {
-                        Ok(t) if !t.trim().is_empty() => t.trim().to_string(),
-                        Ok(_) | Err(_) => {
-                            warn!("GitHub token not configured, skipping issue sync");
-                            return Ok(());
-                        }
-                    },
+            Ok(_) | Err(_) => match self.resolve_github_token_from_env_or_file() {
+                Some(t) => t,
+                None => {
+                    warn!("GitHub token not configured, skipping issue sync");
+                    return Ok(());
                 }
-            }
+            },
         };
 
         let client = github::GithubRestClient::new(&token);
@@ -433,24 +441,15 @@ Before significant work, read the relevant skill file to understand the workflow
 
         let token = match self.resolve_github_token() {
             Ok(t) => t,
-            Err(_) => match config::EnvConfig::from_env()
-                .ok()
-                .and_then(|e| e.github.token)
-            {
-                Some(t) if !t.is_empty() => {
-                    info!("Using GITHUB_TOKEN env var for PR sync");
+            Err(_) => match self.resolve_github_token_from_env_or_file() {
+                Some(t) => {
+                    info!("Using GITHUB_TOKEN env var / token file for PR sync");
                     t
                 }
-                _ => match std::fs::read_to_string("/tmp/github_token") {
-                    Ok(t) if !t.trim().is_empty() => {
-                        info!("Using /tmp/github_token file for PR sync");
-                        t.trim().to_string()
-                    }
-                    Ok(_) | Err(_) => {
-                        warn!("GitHub token not configured, skipping PR sync");
-                        return Ok(());
-                    }
-                },
+                None => {
+                    warn!("GitHub token not configured, skipping PR sync");
+                    return Ok(());
+                }
             },
         };
 
@@ -2471,19 +2470,13 @@ Use `openflows-harness` for all coordination:
 
         let token = match self.resolve_github_token() {
             Ok(t) if !t.is_empty() => t,
-            Ok(_) | Err(_) => match config::EnvConfig::from_env()
-                .ok()
-                .and_then(|e| e.github.token)
-            {
-                Some(t) if !t.is_empty() => t,
-                _ => match std::fs::read_to_string("/tmp/github_token") {
-                    Ok(t) if !t.trim().is_empty() => t.trim().to_string(),
-                    Ok(_) | Err(_) => {
-                        warn!("GitHub token not configured, assuming CI is ready");
-                        store.set(KEY_CI_READINESS, json!(CiReadiness::Ready)).await;
-                        return CiReadiness::Ready;
-                    }
-                },
+            Ok(_) | Err(_) => match self.resolve_github_token_from_env_or_file() {
+                Some(t) => t,
+                None => {
+                    warn!("GitHub token not configured, assuming CI is ready");
+                    store.set(KEY_CI_READINESS, json!(CiReadiness::Ready)).await;
+                    return CiReadiness::Ready;
+                }
             },
         };
 

--- a/crates/agent-sentinel/src/lib.rs
+++ b/crates/agent-sentinel/src/lib.rs
@@ -11,7 +11,7 @@ use config::state::{
     full_ticket_key, full_ticket_key_flat, KEY_TICKETS, KEY_TICKET_CHAT, KEY_TICKET_CHAT_ACTION,
     KEY_TICKET_STATUS, KEY_WORKER_SLOTS,
 };
-use config::{Ticket, TicketStatus, WorkerSlot, WorkerStatus};
+use config::{Envconfig, Ticket, TicketStatus, WorkerSlot, WorkerStatus};
 use pocketflow_core::{node::PAUSE_SIGNAL, Action, Node, SharedStore};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -41,12 +41,13 @@ impl SentinelNode {
     }
 
     async fn coder_client_from_store(store: &SharedStore) -> Option<CoderClient> {
+        let coder = config::CoderConfig::init_from_env().ok();
         let coder_url: Option<String> = store
             .get_typed("coder_url")
             .await
-            .or_else(|| std::env::var("CODER_URL").ok());
-        let coder_token: Option<String> = std::env::var("CODER_SESSION_TOKEN")
-            .ok()
+            .or_else(|| coder.as_ref().map(|c| c.url.clone()));
+        let coder_token: Option<String> = coder
+            .and_then(|c| c.session_token)
             .or_else(|| std::env::var("CODER_API_TOKEN").ok());
         let coder_token = if coder_token.as_deref().is_some_and(|t| !t.is_empty()) {
             coder_token

--- a/crates/agent-sentinel/src/lib.rs
+++ b/crates/agent-sentinel/src/lib.rs
@@ -178,16 +178,15 @@ impl Node for SentinelNode {
                                     "Sentinel chat still running — waiting for review"
                                 );
                             }
-                            ChatStatus::Waiting => {
+                            ChatStatus::Waiting
                                 if (last_action.as_deref() == Some("completed")
                                     || last_action.is_none())
-                                    && !has_review
-                                {
-                                    info!(
-                                        ticket_id = %ticket.id,
-                                        "Sentinel chat waiting but no review written yet — sending follow-up"
-                                    );
-                                }
+                                    && !has_review =>
+                            {
+                                info!(
+                                    ticket_id = %ticket.id,
+                                    "Sentinel chat waiting but no review written yet — sending follow-up"
+                                );
                             }
                             ChatStatus::Error => {
                                 warn!(

--- a/crates/agent-vessel/src/node.rs
+++ b/crates/agent-vessel/src/node.rs
@@ -10,7 +10,7 @@ use config::{
     state::{
         full_ticket_key_flat, KEY_PENDING_PRS, KEY_TICKETS, KEY_TICKET_DEPLOYMENT, KEY_WORKER_SLOTS,
     },
-    Ticket, TicketStatus, WorkerSlot, WorkerStatus, ACTION_CI_FIX_NEEDED,
+    Envconfig, Ticket, TicketStatus, WorkerSlot, WorkerStatus, ACTION_CI_FIX_NEEDED,
     ACTION_CONFLICTS_DETECTED,
 };
 use openflows_notifier::{NotificationMessage, NotificationService};
@@ -38,10 +38,6 @@ pub struct VesselNode {
     poller: CiPoller,
     merger: PrMerger,
 }
-
-/// Environment variable for the workspace root directory.
-/// Used to locate worktrees for local conflict resolution.
-const ENV_WORKSPACE_ROOT: &str = "AGENTFLOW_WORKSPACE_ROOT";
 
 /// Maximum number of conflict resolution attempts before giving up.
 const MAX_CONFLICT_RESOLUTION_ATTEMPTS: u32 = 3;
@@ -71,17 +67,16 @@ impl VesselNode {
 
     pub fn from_env() -> Self {
         // Search for registry in OPENFLOWS_HOME first, then workspace root, then CWD
-        let openflows_home = std::env::var("OPENFLOWS_HOME")
-            .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
-            .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
-            .unwrap_or_else(|_| ".openflows".to_string());
-        let oh_path = std::path::PathBuf::from(&openflows_home)
+        let oh_path = config::TenantConfig::init_from_env()
+            .map(|tenant| tenant.openflows_home())
+            .unwrap_or_else(|_| std::path::PathBuf::from(".openflows"))
             .join("orchestration")
             .join("agent")
             .join("registry.json");
-        let workspace_root = std::env::var("AGENTFLOW_WORKSPACE_ROOT")
-            .map(std::path::PathBuf::from)
-            .ok();
+        let workspace_root = config::AgentConfig::init_from_env()
+            .ok()
+            .and_then(|agent| agent.effective_workspace_root())
+            .map(std::path::PathBuf::from);
         let ws_path = workspace_root
             .as_ref()
             .map(|p| p.join("orchestration").join("agent").join("registry.json"));
@@ -126,7 +121,9 @@ impl VesselNode {
     }
 
     fn resolve_worktree_path(&self, pr_info: &PrInfo) -> Option<PathBuf> {
-        let workspace_root = std::env::var(ENV_WORKSPACE_ROOT).ok()?;
+        let workspace_root = config::AgentConfig::init_from_env()
+            .ok()
+            .and_then(|agent| agent.effective_workspace_root())?;
         let branch = &pr_info.head_branch;
         let parts: Vec<&str> = branch.splitn(2, '/').collect();
         if parts.len() != 2 {
@@ -151,8 +148,9 @@ impl VesselNode {
 
     async fn coder_client_from_store(store: &SharedStore) -> Option<CoderClient> {
         let coder_url: Option<String> = store.get_typed("coder_url").await;
-        let coder_token: Option<String> = std::env::var("CODER_SESSION_TOKEN")
+        let coder_token: Option<String> = config::CoderConfig::init_from_env()
             .ok()
+            .and_then(|coder| coder.session_token)
             .or_else(|| std::env::var("CODER_API_TOKEN").ok());
         let coder_token = if coder_token.as_deref().is_some_and(|t| !t.is_empty()) {
             coder_token
@@ -1715,7 +1713,10 @@ impl VesselNode {
         conflicted_files: &[String],
         fallback_ticket_id: Option<&str>,
     ) -> bool {
-        let workspace_root = match std::env::var(ENV_WORKSPACE_ROOT).ok() {
+        let workspace_root = match config::AgentConfig::init_from_env()
+            .ok()
+            .and_then(|agent| agent.effective_workspace_root())
+        {
             Some(root) => root,
             None => {
                 warn!("AGENTFLOW_WORKSPACE_ROOT not set — cannot write CONFLICT_RESOLUTION.md");
@@ -2306,7 +2307,10 @@ impl VesselNode {
         reason: &str,
         failure_detail: Option<&github::CiFailureDetail>,
     ) -> bool {
-        let workspace_root = match std::env::var(ENV_WORKSPACE_ROOT).ok() {
+        let workspace_root = match config::AgentConfig::init_from_env()
+            .ok()
+            .and_then(|agent| agent.effective_workspace_root())
+        {
             Some(root) => root,
             None => {
                 warn!("AGENTFLOW_WORKSPACE_ROOT not set — cannot write CI_FIX.md");

--- a/crates/agent-vessel/src/types.rs
+++ b/crates/agent-vessel/src/types.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use config::Registry;
+use config::Envconfig;
 use pocketflow_core::{CiPollConfig, MergeMethod};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -32,8 +33,14 @@ impl VesselConfig {
     }
 
     pub fn from_env() -> Self {
-        let github_token = std::env::var("GITHUB_TOKEN")
-            .or_else(|_| std::env::var("CODER_GITHUB_TOKEN"))
+        let github_token = config::GithubConfig::init_from_env()
+            .ok()
+            .and_then(|g| g.token)
+            .or_else(|| {
+                config::CoderConfig::init_from_env()
+                    .ok()
+                    .and_then(|c| c.github_token)
+            })
             .unwrap_or_default();
 
         Self {

--- a/crates/agent-vessel/src/types.rs
+++ b/crates/agent-vessel/src/types.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use config::Registry;
 use config::Envconfig;
+use config::Registry;
 use pocketflow_core::{CiPollConfig, MergeMethod};
 use serde::{Deserialize, Serialize};
 use std::path::Path;

--- a/crates/coder-client/Cargo.toml
+++ b/crates/coder-client/Cargo.toml
@@ -9,6 +9,8 @@ description = "Client library for the Coder REST API"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = "0.22"
+config = { version = "0.2.0", path = "../config" }
+envconfig = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }

--- a/crates/coder-client/src/bootstrap.rs
+++ b/crates/coder-client/src/bootstrap.rs
@@ -7,6 +7,8 @@
 
 use crate::{CoderClient, CreateWorkspaceRequest};
 use anyhow::Result;
+use config::{CoderConfig, GithubConfig, TenantConfig};
+use envconfig::Envconfig;
 use serde_json::json;
 use std::time::Duration;
 use tracing::{info, warn};
@@ -50,12 +52,10 @@ impl CoderBootstrapper {
     /// (uppercase, lowercase, digit, special character, min 8 chars), it is
     /// replaced with the secure default and a warning is logged.
     pub fn from_env() -> Result<Self> {
-        let url =
-            std::env::var("CODER_URL").unwrap_or_else(|_| "http://localhost:7080".to_string());
-        let email = std::env::var("CODER_ADMIN_EMAIL")
-            .unwrap_or_else(|_| "admin@openflows.dev".to_string());
-        let raw_password = std::env::var("CODER_ADMIN_PASSWORD")
-            .unwrap_or_else(|_| SECURE_DEFAULT_PASSWORD.to_string());
+        let cfg = CoderConfig::init_from_env()?;
+        let url = cfg.url.clone();
+        let email = cfg.admin_email.clone();
+        let raw_password = cfg.admin_password.clone();
         let username =
             std::env::var("CODER_ADMIN_USERNAME").unwrap_or_else(|_| "admin".to_string());
 
@@ -108,7 +108,7 @@ impl CoderBootstrapper {
         //     operate as that user instead of creating/logging in as admin.
         //     This lets the system run under any pre-existing Coder user
         //     (e.g. a GitHub-authenticated user) rather than hardcoding admin.
-        if let Ok(existing_token) = std::env::var("CODER_SESSION_TOKEN") {
+        if let Some(existing_token) = CoderConfig::init_from_env()?.session_token {
             if !existing_token.is_empty() {
                 let probe_client = self
                     .client
@@ -330,8 +330,9 @@ impl CoderBootstrapper {
     /// Returns Err if deletion failed — callers must fail bootstrap to avoid
     /// a name conflict when recreating the workspace.
     async fn delete_stale_nexus_workspace(client: &CoderClient) -> Result<()> {
-        let nexus_workspace_name = std::env::var("OPENFLOWS_NEXUS_WORKSPACE_NAME")
-            .unwrap_or_else(|_| "openflows-nexus".to_string());
+        let nexus_workspace_name = TenantConfig::init_from_env()?
+            .nexus_workspace_name
+            .unwrap_or_else(|| "openflows-nexus".to_string());
         let me = client.get_me().await.map_err(|e| {
             anyhow::anyhow!(
                 "Failed to resolve current user while checking for stale nexus workspace '{}': {}. \
@@ -429,29 +430,37 @@ impl CoderBootstrapper {
     /// ready. Callers must fail bootstrap on error so a deleted control plane
     /// is never left without a functional replacement.
     async fn create_nexus_workspace(client: &CoderClient) -> Result<()> {
-        let nexus_workspace_name = std::env::var("OPENFLOWS_NEXUS_WORKSPACE_NAME")
-            .unwrap_or_else(|_| "openflows-nexus".to_string());
-        let nexus_api_token = std::env::var("OPENFLOWS_NEXUS_API_TOKEN")
-            .or_else(|_| std::env::var("NEXUS_CODER_API_TOKEN"))
-            .unwrap_or_else(|_| client.token().to_string());
-        let repository = std::env::var("GITHUB_REPOSITORY").unwrap_or_else(|_| String::new());
+        let tenant_cfg = TenantConfig::init_from_env()?;
+        let github_cfg = GithubConfig::init_from_env()?;
+        let nexus_workspace_name = tenant_cfg
+            .nexus_workspace_name
+            .clone()
+            .unwrap_or_else(|| "openflows-nexus".to_string());
+        let nexus_api_token = tenant_cfg
+            .nexus_api_token
+            .clone()
+            .or_else(|| std::env::var("NEXUS_CODER_API_TOKEN").ok())
+            .unwrap_or_else(|| client.token().to_string());
+        let repository = github_cfg.repository.clone().unwrap_or_default();
         let repo_url = if repository.is_empty() {
             String::new()
         } else {
             format!("https://github.com/{}.git", repository)
         };
         let redis_url = "redis://redis:6379".to_string();
-        let tenant = std::env::var("OPENFLOWS_TENANT").unwrap_or_else(|_| "default".to_string());
-        let registry_json = match std::env::var("OPENFLOWS_REGISTRY_JSON") {
-            Ok(json) => json,
-            Err(_) => {
-                let path = std::env::var("OPENFLOWS_REGISTRY_PATH")
-                    .unwrap_or_else(|_| "orchestration/agent/registry.json".to_string());
+        let tenant = tenant_cfg.effective_tenant().to_string();
+        let registry_json = match tenant_cfg.registry_json.clone() {
+            Some(json) => json,
+            None => {
+                let path = tenant_cfg
+                    .registry_path
+                    .clone()
+                    .unwrap_or_else(|| "orchestration/agent/registry.json".to_string());
                 std::fs::read_to_string(&path).unwrap_or_default()
             }
         };
         let coder_url_for_workspace = client.base_url().replace("localhost", "coder");
-        let github_pat = std::env::var("GITHUB_TOKEN").unwrap_or_default();
+        let github_pat = github_cfg.token.clone().unwrap_or_default();
 
         let workspace = client
             .create_workspace(&CreateWorkspaceRequest {
@@ -713,7 +722,9 @@ impl CoderBootstrapper {
         let nexus_workspace_name = format!("openflows-nexus-{}", tenant_name);
         let repo_url = format!("https://github.com/{}.git", github_repo);
 
-        let github_pat = std::env::var("GITHUB_TOKEN").unwrap_or_default();
+        let github_pat = GithubConfig::init_from_env()?
+            .token
+            .unwrap_or_default();
         let workspace = client
             .create_workspace_for_user(
                 &tenant_user.id,

--- a/crates/coder-client/src/bootstrap.rs
+++ b/crates/coder-client/src/bootstrap.rs
@@ -233,7 +233,7 @@ impl CoderBootstrapper {
         // any stale workspace. If creation is disabled, we must preserve the
         // existing one.
         let env_cfg = load_env(env)?;
-        let create_nexus_workspace = env_cfg.agent.create_nexus_workspace.unwrap_or(true)
+        let create_nexus_workspace = env_cfg.agent.create_nexus_workspace_enabled()
             && env_cfg.agent.role.as_deref() != Some("nexus");
 
         // Track template push failures — bootstrap must fail if required

--- a/crates/coder-client/src/bootstrap.rs
+++ b/crates/coder-client/src/bootstrap.rs
@@ -722,9 +722,7 @@ impl CoderBootstrapper {
         let nexus_workspace_name = format!("openflows-nexus-{}", tenant_name);
         let repo_url = format!("https://github.com/{}.git", github_repo);
 
-        let github_pat = GithubConfig::init_from_env()?
-            .token
-            .unwrap_or_default();
+        let github_pat = GithubConfig::init_from_env()?.token.unwrap_or_default();
         let workspace = client
             .create_workspace_for_user(
                 &tenant_user.id,

--- a/crates/coder-client/src/bootstrap.rs
+++ b/crates/coder-client/src/bootstrap.rs
@@ -7,7 +7,7 @@
 
 use crate::{CoderClient, CreateWorkspaceRequest};
 use anyhow::Result;
-use config::{CoderConfig, GithubConfig, TenantConfig};
+use config::{CoderConfig, GithubConfig};
 use envconfig::Envconfig;
 use serde_json::json;
 use std::time::Duration;
@@ -19,10 +19,23 @@ pub struct CoderBootstrapper {
     admin_email: String,
     admin_password: String,
     admin_username: String,
+    /// Configuration loaded once at startup, reused across the bootstrap flow
+    /// instead of re-parsing `std::env::var(...)` per step.
+    env: Option<config::EnvConfig>,
 }
 
 /// Default admin password that meets Coder's security requirements.
 const SECURE_DEFAULT_PASSWORD: &str = "Op3nFl0ws!";
+
+/// Resolve an already-loaded [`config::EnvConfig`], falling back to parsing the
+/// process environment for callers (e.g. [`CoderBootstrapper::new`]) that were
+/// not constructed from the environment.
+fn load_env(env: Option<&config::EnvConfig>) -> Result<config::EnvConfig> {
+    match env {
+        Some(env) => Ok(env.clone()),
+        None => config::EnvConfig::from_env(),
+    }
+}
 
 /// Check whether a password meets Coder's minimum security requirements.
 ///
@@ -52,12 +65,11 @@ impl CoderBootstrapper {
     /// (uppercase, lowercase, digit, special character, min 8 chars), it is
     /// replaced with the secure default and a warning is logged.
     pub fn from_env() -> Result<Self> {
-        let cfg = CoderConfig::init_from_env()?;
-        let url = cfg.url.clone();
-        let email = cfg.admin_email.clone();
-        let raw_password = cfg.admin_password.clone();
-        let username =
-            std::env::var("CODER_ADMIN_USERNAME").unwrap_or_else(|_| "admin".to_string());
+        let env = config::EnvConfig::from_env()?;
+        let url = env.coder.url.clone();
+        let email = env.coder.admin_email.clone();
+        let raw_password = env.coder.admin_password.clone().unwrap_or_default();
+        let username = env.coder.admin_username.clone();
 
         let password = if password_meets_coder_requirements(&raw_password) {
             raw_password
@@ -77,6 +89,7 @@ impl CoderBootstrapper {
             admin_email: email,
             admin_password: password,
             admin_username: username,
+            env: Some(env),
         })
     }
 
@@ -88,6 +101,7 @@ impl CoderBootstrapper {
             admin_email: email.to_string(),
             admin_password: password.to_string(),
             admin_username: username.to_string(),
+            env: None,
         }
     }
 
@@ -108,26 +122,33 @@ impl CoderBootstrapper {
         //     operate as that user instead of creating/logging in as admin.
         //     This lets the system run under any pre-existing Coder user
         //     (e.g. a GitHub-authenticated user) rather than hardcoding admin.
-        if let Some(existing_token) = CoderConfig::init_from_env()?.session_token {
-            if !existing_token.is_empty() {
-                let probe_client = self
-                    .client
-                    .with_token(existing_token.clone())
+        let existing_token = self
+            .env
+            .as_ref()
+            .and_then(|e| e.coder.session_token.clone())
+            .or_else(|| {
+                CoderConfig::init_from_env()
+                    .ok()
+                    .and_then(|c| c.session_token)
+            });
+        if let Some(existing_token) = existing_token.filter(|t| !t.is_empty()) {
+            let probe_client = self
+                .client
+                .with_token(existing_token.clone())
+                .with_session_token(&existing_token);
+            if let Ok(me) = probe_client.get_me().await {
+                info!(
+                    username = %me.username,
+                    user_id = %me.id,
+                    "  ✓ Reusing existing CODER_SESSION_TOKEN for user '{}' — skipping admin bootstrap",
+                    me.username
+                );
+                let api_key = probe_client.create_api_token(&me.id, "openflows").await?;
+                let client = probe_client
+                    .with_token(api_key.key.clone())
                     .with_session_token(&existing_token);
-                if let Ok(me) = probe_client.get_me().await {
-                    info!(
-                        username = %me.username,
-                        user_id = %me.id,
-                        "  ✓ Reusing existing CODER_SESSION_TOKEN for user '{}' — skipping admin bootstrap",
-                        me.username
-                    );
-                    let api_key = probe_client.create_api_token(&me.id, "openflows").await?;
-                    let client = probe_client
-                        .with_token(api_key.key.clone())
-                        .with_session_token(&existing_token);
-                    info!("  ✓ API token generated for '{}'", me.username);
-                    return Self::push_templates_and_create_nexus(client).await;
-                }
+                info!("  ✓ API token generated for '{}'", me.username);
+                return Self::push_templates_and_create_nexus(client, self.env.as_ref()).await;
             }
         }
 
@@ -186,13 +207,16 @@ impl CoderBootstrapper {
             .with_session_token(&session_token);
         info!("  ✓ API token generated");
 
-        Self::push_templates_and_create_nexus(client).await
+        Self::push_templates_and_create_nexus(client, self.env.as_ref()).await
     }
 
     /// Shared post-auth logic: push templates and create the nexus workspace.
     /// Used by both the "reuse existing token" fast path and the full admin
     /// bootstrap path.
-    async fn push_templates_and_create_nexus(client: CoderClient) -> Result<CoderClient> {
+    async fn push_templates_and_create_nexus(
+        client: CoderClient,
+        env: Option<&config::EnvConfig>,
+    ) -> Result<CoderClient> {
         let resolved_user = client.resolve_current_user().await?;
         info!(
             username = %resolved_user,
@@ -208,10 +232,9 @@ impl CoderBootstrapper {
         // Check whether nexus workspace creation is enabled before deleting
         // any stale workspace. If creation is disabled, we must preserve the
         // existing one.
-        let create_nexus_workspace = std::env::var("OPENFLOWS_CREATE_NEXUS_WORKSPACE")
-            .map(|v| v != "false")
-            .unwrap_or(true)
-            && std::env::var("ROLE").as_deref() != Ok("nexus");
+        let env_cfg = load_env(env)?;
+        let create_nexus_workspace = env_cfg.agent.create_nexus_workspace.unwrap_or(true)
+            && env_cfg.agent.role.as_deref() != Some("nexus");
 
         // Track template push failures — bootstrap must fail if required
         // templates cannot be pushed, so the caller knows provisioning is
@@ -287,7 +310,7 @@ impl CoderBootstrapper {
         // OPENFLOWS_CREATE_NEXUS_WORKSPACE=false or ROLE=nexus, preserving
         // the existing control plane avoids a window with no workspace.
         if nexus_template_updated && create_nexus_workspace {
-            Self::delete_stale_nexus_workspace(&client).await?;
+            Self::delete_stale_nexus_workspace(&client, env).await?;
         }
 
         // Create or refresh the long-lived Nexus workspace outside Coder.
@@ -295,7 +318,7 @@ impl CoderBootstrapper {
         // This is the bootstrapper's "first mover" responsibility: seed the
         // persistent control-plane workspace that runs the orchestration loop.
         if create_nexus_workspace {
-            Self::create_nexus_workspace(&client).await?;
+            Self::create_nexus_workspace(&client, env).await?;
         }
 
         info!("  ✓ Coder bootstrapped");
@@ -329,8 +352,13 @@ impl CoderBootstrapper {
     /// Returns Ok if no workspace existed, or after successful deletion.
     /// Returns Err if deletion failed — callers must fail bootstrap to avoid
     /// a name conflict when recreating the workspace.
-    async fn delete_stale_nexus_workspace(client: &CoderClient) -> Result<()> {
-        let nexus_workspace_name = TenantConfig::init_from_env()?
+    async fn delete_stale_nexus_workspace(
+        client: &CoderClient,
+        env: Option<&config::EnvConfig>,
+    ) -> Result<()> {
+        let env_cfg = load_env(env)?;
+        let nexus_workspace_name = env_cfg
+            .tenant
             .nexus_workspace_name
             .unwrap_or_else(|| "openflows-nexus".to_string());
         let me = client.get_me().await.map_err(|e| {
@@ -429,9 +457,13 @@ impl CoderBootstrapper {
     /// Returns Err if the workspace could not be created or did not become
     /// ready. Callers must fail bootstrap on error so a deleted control plane
     /// is never left without a functional replacement.
-    async fn create_nexus_workspace(client: &CoderClient) -> Result<()> {
-        let tenant_cfg = TenantConfig::init_from_env()?;
-        let github_cfg = GithubConfig::init_from_env()?;
+    async fn create_nexus_workspace(
+        client: &CoderClient,
+        env: Option<&config::EnvConfig>,
+    ) -> Result<()> {
+        let env_cfg = load_env(env)?;
+        let tenant_cfg = &env_cfg.tenant;
+        let github_cfg = &env_cfg.github;
         let nexus_workspace_name = tenant_cfg
             .nexus_workspace_name
             .clone()
@@ -722,7 +754,12 @@ impl CoderBootstrapper {
         let nexus_workspace_name = format!("openflows-nexus-{}", tenant_name);
         let repo_url = format!("https://github.com/{}.git", github_repo);
 
-        let github_pat = GithubConfig::init_from_env()?.token.unwrap_or_default();
+        let github_pat = self
+            .env
+            .as_ref()
+            .and_then(|e| e.github.token.clone())
+            .or_else(|| GithubConfig::init_from_env().ok().and_then(|c| c.token))
+            .unwrap_or_default();
         let workspace = client
             .create_workspace_for_user(
                 &tenant_user.id,

--- a/crates/coder-client/src/lib.rs
+++ b/crates/coder-client/src/lib.rs
@@ -25,6 +25,8 @@ pub mod mock_chat_server;
 pub use types::*;
 
 use anyhow::{bail, Context, Result};
+use config::{GithubConfig, TenantConfig};
+use envconfig::Envconfig;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -1533,8 +1535,9 @@ impl CoderClient {
 
         // Build naming convention: {role}-{ticket_id} — ticket_id already includes "T-" prefix
         let workspace_name = format!("{}-{}", role, ticket_id);
-        let repository: String =
-            std::env::var("GITHUB_REPOSITORY").unwrap_or_else(|_| "openflows/target".to_string());
+        let repository: String = GithubConfig::init_from_env()?
+            .repository
+            .unwrap_or_else(|| "openflows/target".to_string());
         let repo_url = format!("https://github.com/{}.git", repository);
         let template_name = format!("openflows-{}", role);
 
@@ -1576,7 +1579,7 @@ impl CoderClient {
         let model_config_id = None;
 
         // Create chat with OpenFlows labels (includes tenant)
-        let tenant = std::env::var("OPENFLOWS_TENANT").unwrap_or_else(|_| "default".to_string());
+        let tenant = TenantConfig::init_from_env()?.effective_tenant().to_string();
         let labels = build_chat_labels(ticket_id, role, "openflows", &tenant);
         let chat_req = CreateChatRequest {
             organization_id,

--- a/crates/coder-client/src/lib.rs
+++ b/crates/coder-client/src/lib.rs
@@ -1579,7 +1579,9 @@ impl CoderClient {
         let model_config_id = None;
 
         // Create chat with OpenFlows labels (includes tenant)
-        let tenant = TenantConfig::init_from_env()?.effective_tenant().to_string();
+        let tenant = TenantConfig::init_from_env()?
+            .effective_tenant()
+            .to_string();
         let labels = build_chat_labels(ticket_id, role, "openflows", &tenant);
         let chat_req = CreateChatRequest {
             organization_id,

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 
 [dependencies]
 anyhow      = { workspace = true }
+envconfig   = { workspace = true }
 serde       = { workspace = true }
 serde_json  = { workspace = true }
 serde_yaml  = { workspace = true }

--- a/crates/config/src/env.rs
+++ b/crates/config/src/env.rs
@@ -1,0 +1,318 @@
+//! Centralized environment configuration.
+//!
+//! All process-startup configuration is defined here as [`envconfig`] -derived
+//! structs so that env-var reads are type-safe, validated, and initialized once
+//! at startup instead of being scattered as inline `std::env::var(...)` calls
+//! across the workspace.
+//!
+//! The structs intentionally use conservative defaults so existing deployments
+//! keep working, while required values (e.g. Coder auth tokens in the
+//! controller) surface clear errors at startup.
+
+use envconfig::Envconfig;
+use std::path::PathBuf;
+
+/// Coder-related configuration.
+#[derive(Debug, Clone, Envconfig)]
+pub struct CoderConfig {
+    #[envconfig(from = "CODER_URL", default = "http://localhost:7080")]
+    pub url: String,
+
+    #[envconfig(from = "CODER_SESSION_TOKEN")]
+    pub session_token: Option<String>,
+
+    #[envconfig(from = "CODER_ADMIN_EMAIL", default = "admin@openflows.dev")]
+    pub admin_email: String,
+
+    #[envconfig(from = "CODER_ADMIN_PASSWORD", default = "Op3nFl0ws!")]
+    pub admin_password: String,
+
+    #[envconfig(from = "CODER_IMAGE_TAG", default = "latest")]
+    pub image_tag: String,
+
+    #[envconfig(from = "CODER_GITHUB_TOKEN")]
+    pub github_token: Option<String>,
+
+    #[envconfig(from = "CODER_EXTERNAL_AUTH_0_ID")]
+    pub external_auth_id: Option<String>,
+
+    #[envconfig(from = "CODER_EXTERNAL_AUTH_0_SECRET")]
+    pub external_auth_secret: Option<String>,
+}
+
+impl CoderConfig {
+    /// Resolve the effective Coder auth token (the session token).
+    pub fn effective_token(&self) -> Option<String> {
+        self.session_token.clone()
+    }
+}
+
+/// Infrastructure configuration (Redis, A2A relay).
+#[derive(Debug, Clone, Envconfig)]
+pub struct InfraConfig {
+    #[envconfig(from = "REDIS_URL", default = "redis://localhost:6379")]
+    pub redis_url: String,
+
+    #[envconfig(from = "A2A_RELAY_ADDR", default = "127.0.0.1:3000")]
+    pub a2a_relay_addr: String,
+}
+
+/// OpenFlows tenant / namespace configuration.
+#[derive(Debug, Clone, Envconfig)]
+pub struct TenantConfig {
+    #[envconfig(from = "OPENFLOWS_TENANT", default = "default")]
+    pub tenant: String,
+
+    #[envconfig(from = "OPENFLOWS_TICKET")]
+    pub ticket: Option<String>,
+
+    #[envconfig(from = "OPENFLOWS_ROLE")]
+    pub role: Option<String>,
+
+    #[envconfig(from = "OPENFLOWS_HOME")]
+    pub home: Option<String>,
+
+    #[envconfig(from = "OPENFLOWS_REGISTRY_PATH")]
+    pub registry_path: Option<String>,
+
+    #[envconfig(from = "OPENFLOWS_REGISTRY_JSON")]
+    pub registry_json: Option<String>,
+
+    #[envconfig(from = "OPENFLOWS_NEXUS_WORKSPACE_ID")]
+    pub nexus_workspace_id: Option<String>,
+
+    #[envconfig(from = "OPENFLOWS_NEXUS_WORKSPACE_NAME")]
+    pub nexus_workspace_name: Option<String>,
+
+    #[envconfig(from = "OPENFLOWS_NEXUS_API_TOKEN")]
+    pub nexus_api_token: Option<String>,
+
+    #[envconfig(from = "OPENFLOWS_TAR", default = "tar")]
+    pub tar: String,
+}
+
+impl TenantConfig {
+    /// Resolve the OpenFlows home directory, defaulting to `~/.openflows`.
+    pub fn openflows_home(&self) -> PathBuf {
+        if let Some(home) = &self.home {
+            return PathBuf::from(home);
+        }
+        let base = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .unwrap_or_else(|_| ".".into());
+        PathBuf::from(base).join(".openflows")
+    }
+}
+
+/// GitHub-related configuration.
+#[derive(Debug, Clone, Envconfig)]
+pub struct GithubConfig {
+    #[envconfig(from = "GITHUB_REPOSITORY")]
+    pub repository: Option<String>,
+
+    #[envconfig(from = "GITHUB_TOKEN")]
+    pub token: Option<String>,
+
+    #[envconfig(from = "GITHUB_PERSONAL_ACCESS_TOKEN")]
+    pub personal_access_token: Option<String>,
+}
+
+impl GithubConfig {
+    /// Effective GitHub token, preferring the personal access token and falling
+    /// back to the generic `GITHUB_TOKEN`.
+    pub fn effective_token(&self) -> Option<String> {
+        self.personal_access_token
+            .clone()
+            .or_else(|| self.token.clone())
+    }
+}
+
+/// Agent/workspace configuration.
+#[derive(Debug, Clone, Envconfig)]
+pub struct AgentConfig {
+    #[envconfig(from = "AGENTFLOW_WORKSPACE_ROOT")]
+    pub workspace_root: Option<String>,
+
+    #[envconfig(from = "WORKSPACE_ROOT")]
+    pub legacy_workspace_root: Option<String>,
+
+    #[envconfig(from = "USE_AI_GATEWAY", default = "false")]
+    pub use_ai_gateway: bool,
+}
+
+impl AgentConfig {
+    /// Resolve the effective workspace root across the two accepted names.
+    pub fn effective_workspace_root(&self) -> Option<String> {
+        self.workspace_root
+            .clone()
+            .or_else(|| self.legacy_workspace_root.clone())
+    }
+}
+
+/// Aggregated environment configuration loaded once at startup.
+#[derive(Debug, Clone)]
+pub struct EnvConfig {
+    pub coder: CoderConfig,
+    pub infra: InfraConfig,
+    pub tenant: TenantConfig,
+    pub github: GithubConfig,
+    pub agent: AgentConfig,
+}
+
+impl EnvConfig {
+    /// Validate the fields required to run the OpenFlows controller (in a
+    /// nexus workspace). Returns a clear error naming the first missing value.
+    ///
+    /// # Errors
+    /// Returns an error when a controller-required variable is not set.
+    pub fn validate_controller(&self) -> anyhow::Result<()> {
+        if self.coder.effective_token().is_none() {
+            anyhow::bail!(
+                "CODER_SESSION_TOKEN is not set. The Controller must run inside an \
+                 openflows-nexus workspace."
+            );
+        }
+        if self.tenant.tenant.is_empty() {
+            anyhow::bail!(
+                "OPENFLOWS_TENANT is not set. The Controller must run inside an \
+                 openflows-nexus workspace."
+            );
+        }
+        if self
+            .github
+            .repository
+            .as_deref()
+            .unwrap_or_default()
+            .is_empty()
+        {
+            anyhow::bail!(
+                "GITHUB_REPOSITORY is not set. The Controller must run inside an \
+                 openflows-nexus workspace."
+            );
+        }
+        Ok(())
+    }
+
+    /// Initialize all config structs from the environment, returning a clear
+    /// error naming any missing/invalid variable. The caller decides whether to
+    /// load a `.env` file first (e.g. via `dotenvy::dotenv()`); this function
+    /// reads the already-populated process environment only, which keeps it
+    /// deterministic and testable.
+    ///
+    /// # Errors
+    /// Returns an error if any required environment variable is missing or a
+    /// supplied value fails to parse.
+    pub fn from_env() -> anyhow::Result<Self> {
+        let coder =
+            CoderConfig::init_from_env().map_err(|e| anyhow::anyhow!("Coder config: {e}"))?;
+        let infra =
+            InfraConfig::init_from_env().map_err(|e| anyhow::anyhow!("Infra config: {e}"))?;
+        let tenant =
+            TenantConfig::init_from_env().map_err(|e| anyhow::anyhow!("Tenant config: {e}"))?;
+        let github =
+            GithubConfig::init_from_env().map_err(|e| anyhow::anyhow!("GitHub config: {e}"))?;
+        let agent =
+            AgentConfig::init_from_env().map_err(|e| anyhow::anyhow!("Agent config: {e}"))?;
+
+        Ok(Self {
+            coder,
+            infra,
+            tenant,
+            github,
+            agent,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear(keys: &[&str]) {
+        for k in keys {
+            unsafe {
+                std::env::remove_var(k);
+            }
+        }
+    }
+
+    #[test]
+    fn defaults_applied_when_unset() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear(&[
+            "CODER_URL",
+            "CODER_ADMIN_EMAIL",
+            "CODER_ADMIN_PASSWORD",
+            "CODER_IMAGE_TAG",
+            "REDIS_URL",
+            "A2A_RELAY_ADDR",
+            "OPENFLOWS_TENANT",
+            "OPENFLOWS_TAR",
+            "USE_AI_GATEWAY",
+        ]);
+        let cfg = EnvConfig::from_env().unwrap();
+        assert_eq!(cfg.coder.url, "http://localhost:7080");
+        assert_eq!(cfg.coder.admin_email, "admin@openflows.dev");
+        assert_eq!(cfg.coder.admin_password, "Op3nFl0ws!");
+        assert_eq!(cfg.coder.image_tag, "latest");
+        assert_eq!(cfg.infra.redis_url, "redis://localhost:6379");
+        assert_eq!(cfg.infra.a2a_relay_addr, "127.0.0.1:3000");
+        assert_eq!(cfg.tenant.tenant, "default");
+        assert_eq!(cfg.tenant.tar, "tar");
+        assert!(!cfg.agent.use_ai_gateway);
+    }
+
+    #[test]
+    fn overrides_from_env() {
+        let _g = ENV_LOCK.lock().unwrap();
+        for (k, v) in [
+            ("CODER_URL", "http://coder.example.com:8080"),
+            ("REDIS_URL", "redis://redis.example.com:6379"),
+            ("OPENFLOWS_TENANT", "acme"),
+            ("USE_AI_GATEWAY", "true"),
+        ] {
+            unsafe {
+                std::env::set_var(k, v);
+            }
+        }
+        let cfg = EnvConfig::from_env().unwrap();
+        assert_eq!(cfg.coder.url, "http://coder.example.com:8080");
+        assert_eq!(cfg.infra.redis_url, "redis://redis.example.com:6379");
+        assert_eq!(cfg.tenant.tenant, "acme");
+        assert!(cfg.agent.use_ai_gateway);
+        clear(&[
+            "CODER_URL",
+            "REDIS_URL",
+            "OPENFLOWS_TENANT",
+            "USE_AI_GATEWAY",
+        ]);
+    }
+
+    #[test]
+    fn parse_error_for_invalid_bool() {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var("USE_AI_GATEWAY", "not-a-bool");
+        }
+        let err = EnvConfig::from_env().unwrap_err();
+        assert!(format!("{err}").contains("Agent config"));
+        unsafe {
+            std::env::remove_var("USE_AI_GATEWAY");
+        }
+    }
+
+    #[test]
+    fn openflows_home_defaults_to_tilde() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear(&["OPENFLOWS_HOME", "HOME", "USERPROFILE"]);
+        let cfg = EnvConfig::from_env().unwrap();
+        assert!(cfg
+            .tenant
+            .openflows_home()
+            .to_string_lossy()
+            .ends_with(".openflows"));
+    }
+}

--- a/crates/config/src/env.rs
+++ b/crates/config/src/env.rs
@@ -226,12 +226,12 @@ pub struct AgentConfig {
 
     /// Whether the AI gateway is enabled.
     #[envconfig(from = "USE_AI_GATEWAY")]
-    pub use_ai_gateway: Option<bool>,
+    pub use_ai_gateway: Option<String>,
 
     /// Whether the bootstrapper should create the Nexus control-plane
-    /// workspace. Defaults to enabled; only an explicit `false` disables it.
+    /// workspace.
     #[envconfig(from = "OPENFLOWS_CREATE_NEXUS_WORKSPACE")]
-    pub create_nexus_workspace: Option<bool>,
+    pub create_nexus_workspace: Option<String>,
 
     /// The role this process runs as (e.g. `nexus`).
     #[envconfig(from = "ROLE")]
@@ -248,7 +248,13 @@ impl AgentConfig {
 
     /// Whether the AI gateway is enabled.
     pub fn use_ai_gateway_enabled(&self) -> bool {
-        self.use_ai_gateway.unwrap_or(false)
+        matches!(self.use_ai_gateway.as_deref(), Some("true" | "1"))
+    }
+
+    /// Whether the bootstrapper should create the Nexus control-plane
+    /// workspace.
+    pub fn create_nexus_workspace_enabled(&self) -> bool {
+        self.create_nexus_workspace.as_deref() != Some("false")
     }
 }
 
@@ -426,16 +432,47 @@ mod tests {
     }
 
     #[test]
-    fn ai_gateway_accepts_valid_values() {
+    fn ai_gateway_accepts_valid_values_without_aborting() {
         let _g = ENV_LOCK.lock().unwrap();
         let _guard = EnvGuard::capture(&["USE_AI_GATEWAY"]);
-        for (v, expected) in [("true", true), ("false", false)] {
+        for (v, expected) in [
+            ("true", true),
+            ("1", true),
+            ("false", false),
+            ("garbage", false),
+        ] {
             std::env::set_var("USE_AI_GATEWAY", v);
             let cfg = EnvConfig::from_env().unwrap();
             assert_eq!(
                 cfg.agent.use_ai_gateway_enabled(),
                 expected,
                 "USE_AI_GATEWAY={v}"
+            );
+        }
+    }
+
+    #[test]
+    fn create_nexus_workspace_is_lenient_and_defaults_enabled() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::capture(&["OPENFLOWS_CREATE_NEXUS_WORKSPACE"]);
+        std::env::remove_var("OPENFLOWS_CREATE_NEXUS_WORKSPACE");
+        assert!(EnvConfig::from_env()
+            .unwrap()
+            .agent
+            .create_nexus_workspace_enabled());
+
+        for (v, expected) in [
+            ("false", false),
+            ("true", true),
+            ("1", true),
+            ("garbage", true),
+        ] {
+            std::env::set_var("OPENFLOWS_CREATE_NEXUS_WORKSPACE", v);
+            let cfg = EnvConfig::from_env().unwrap();
+            assert_eq!(
+                cfg.agent.create_nexus_workspace_enabled(),
+                expected,
+                "OPENFLOWS_CREATE_NEXUS_WORKSPACE={v}"
             );
         }
     }

--- a/crates/config/src/env.rs
+++ b/crates/config/src/env.rs
@@ -26,8 +26,14 @@ pub struct CoderConfig {
     #[envconfig(from = "CODER_ADMIN_EMAIL", default = "admin@openflows.dev")]
     pub admin_email: String,
 
-    #[envconfig(from = "CODER_ADMIN_PASSWORD", default = "Op3nFl0ws!")]
-    pub admin_password: String,
+    /// Admin password for the initial Coder user. No default is baked in:
+    /// the bootstrapper applies its own secure fallback only when the value is
+    /// absent or fails Coder's password policy.
+    #[envconfig(from = "CODER_ADMIN_PASSWORD")]
+    pub admin_password: Option<String>,
+
+    #[envconfig(from = "CODER_ADMIN_USERNAME", default = "admin")]
+    pub admin_username: String,
 
     #[envconfig(from = "CODER_IMAGE_TAG", default = "latest")]
     pub image_tag: String,
@@ -56,6 +62,7 @@ impl fmt::Debug for CoderConfig {
             .field("session_token", &redact(&self.session_token))
             .field("admin_email", &self.admin_email)
             .field("admin_password", &"<redacted>")
+            .field("admin_username", &self.admin_username)
             .field("image_tag", &self.image_tag)
             .field("github_token", &redact(&self.github_token))
             .field("external_auth_client_id", &self.external_auth_client_id)
@@ -207,14 +214,28 @@ impl fmt::Debug for GithubConfig {
 /// Agent/workspace configuration.
 #[derive(Debug, Clone, Envconfig)]
 pub struct AgentConfig {
+    /// Preferred workspace root, sourced from `AGENTFLOW_WORKSPACE_ROOT`.
     #[envconfig(from = "AGENTFLOW_WORKSPACE_ROOT")]
     pub workspace_root: Option<String>,
 
+    /// Fallback workspace root sourced from the legacy `WORKSPACE_ROOT`
+    /// variable. [`AgentConfig::effective_workspace_root`] prefers
+    /// [`Self::workspace_root`] and only falls back to this one.
     #[envconfig(from = "WORKSPACE_ROOT")]
     pub legacy_workspace_root: Option<String>,
 
+    /// Whether the AI gateway is enabled.
     #[envconfig(from = "USE_AI_GATEWAY")]
-    pub use_ai_gateway: Option<String>,
+    pub use_ai_gateway: Option<bool>,
+
+    /// Whether the bootstrapper should create the Nexus control-plane
+    /// workspace. Defaults to enabled; only an explicit `false` disables it.
+    #[envconfig(from = "OPENFLOWS_CREATE_NEXUS_WORKSPACE")]
+    pub create_nexus_workspace: Option<bool>,
+
+    /// The role this process runs as (e.g. `nexus`).
+    #[envconfig(from = "ROLE")]
+    pub role: Option<String>,
 }
 
 impl AgentConfig {
@@ -225,11 +246,9 @@ impl AgentConfig {
             .or_else(|| self.legacy_workspace_root.clone())
     }
 
-    /// Whether the AI gateway is enabled. Accepts the same values the existing
-    /// registry parser does (`"true"` or `"1"`); anything else is treated as
-    /// disabled rather than aborting startup.
+    /// Whether the AI gateway is enabled.
     pub fn use_ai_gateway_enabled(&self) -> bool {
-        matches!(self.use_ai_gateway.as_deref(), Some("true" | "1"))
+        self.use_ai_gateway.unwrap_or(false)
     }
 }
 
@@ -334,9 +353,7 @@ mod tests {
 
         fn unset_all(&self) {
             for (k, _) in &self.snapshots {
-                unsafe {
-                    std::env::remove_var(k);
-                }
+                std::env::remove_var(k);
             }
         }
     }
@@ -345,12 +362,8 @@ mod tests {
         fn drop(&mut self) {
             for (k, v) in &self.snapshots {
                 match v {
-                    Some(val) => unsafe {
-                        std::env::set_var(k, val);
-                    },
-                    None => unsafe {
-                        std::env::remove_var(k);
-                    },
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
                 }
             }
         }
@@ -374,12 +387,14 @@ mod tests {
         let cfg = EnvConfig::from_env().unwrap();
         assert_eq!(cfg.coder.url, "http://localhost:7080");
         assert_eq!(cfg.coder.admin_email, "admin@openflows.dev");
-        assert_eq!(cfg.coder.admin_password, "Op3nFl0ws!");
+        assert_eq!(cfg.coder.admin_username, "admin");
+        assert_eq!(cfg.coder.admin_password, None);
         assert_eq!(cfg.coder.image_tag, "latest");
         assert_eq!(cfg.infra.effective_redis_url(), "redis://localhost:6379");
         assert_eq!(cfg.infra.a2a_relay_addr, "127.0.0.1:3000");
         assert_eq!(cfg.tenant.effective_tenant(), "default");
         assert_eq!(cfg.tenant.tar, "tar");
+        assert_eq!(cfg.agent.use_ai_gateway, None);
         assert!(!cfg.agent.use_ai_gateway_enabled());
     }
 
@@ -396,11 +411,9 @@ mod tests {
             ("CODER_URL", "http://coder.example.com:8080"),
             ("REDIS_URL", "redis://redis.example.com:6379"),
             ("OPENFLOWS_TENANT", "acme"),
-            ("USE_AI_GATEWAY", "1"),
+            ("USE_AI_GATEWAY", "true"),
         ] {
-            unsafe {
-                std::env::set_var(k, v);
-            }
+            std::env::set_var(k, v);
         }
         let cfg = EnvConfig::from_env().unwrap();
         assert_eq!(cfg.coder.url, "http://coder.example.com:8080");
@@ -413,19 +426,11 @@ mod tests {
     }
 
     #[test]
-    fn ai_gateway_accepts_previous_valid_values() {
+    fn ai_gateway_accepts_valid_values() {
         let _g = ENV_LOCK.lock().unwrap();
         let _guard = EnvGuard::capture(&["USE_AI_GATEWAY"]);
-        for (v, expected) in [
-            ("1", true),
-            ("true", true),
-            ("0", false),
-            ("false", false),
-            ("garbage", false),
-        ] {
-            unsafe {
-                std::env::set_var("USE_AI_GATEWAY", v);
-            }
+        for (v, expected) in [("true", true), ("false", false)] {
+            std::env::set_var("USE_AI_GATEWAY", v);
             let cfg = EnvConfig::from_env().unwrap();
             assert_eq!(
                 cfg.agent.use_ai_gateway_enabled(),
@@ -439,10 +444,8 @@ mod tests {
     fn debug_redacts_secrets() {
         let _g = ENV_LOCK.lock().unwrap();
         let _guard = EnvGuard::capture(&["CODER_SESSION_TOKEN", "CODER_ADMIN_PASSWORD"]);
-        unsafe {
-            std::env::set_var("CODER_SESSION_TOKEN", "s3cr3t-token");
-            std::env::set_var("CODER_ADMIN_PASSWORD", "hunter2");
-        }
+        std::env::set_var("CODER_SESSION_TOKEN", "s3cr3t-token");
+        std::env::set_var("CODER_ADMIN_PASSWORD", "hunter2");
         let cfg = EnvConfig::from_env().unwrap();
         let dbg = format!("{:?}", cfg.coder);
         assert!(dbg.contains("<redacted>"));

--- a/crates/config/src/env.rs
+++ b/crates/config/src/env.rs
@@ -176,6 +176,9 @@ pub struct GithubConfig {
 
     #[envconfig(from = "GITHUB_PERSONAL_ACCESS_TOKEN")]
     pub personal_access_token: Option<String>,
+
+    #[envconfig(from = "GITHUB_API_BASE", default = "https://api.github.com")]
+    pub api_base: String,
 }
 
 impl GithubConfig {

--- a/crates/config/src/env.rs
+++ b/crates/config/src/env.rs
@@ -1,19 +1,21 @@
 //! Centralized environment configuration.
 //!
-//! All process-startup configuration is defined here as [`envconfig`] -derived
+//! All process-startup configuration is defined here as [`envconfig`]-derived
 //! structs so that env-var reads are type-safe, validated, and initialized once
 //! at startup instead of being scattered as inline `std::env::var(...)` calls
 //! across the workspace.
 //!
-//! The structs intentionally use conservative defaults so existing deployments
-//! keep working, while required values (e.g. Coder auth tokens in the
-//! controller) surface clear errors at startup.
+//! Secrets (tokens, passwords) are redacted from [`std::fmt::Debug`] output so
+//! configuration never leaks credentials into logs or error diagnostics.
 
 use envconfig::Envconfig;
+use std::fmt;
 use std::path::PathBuf;
 
 /// Coder-related configuration.
-#[derive(Debug, Clone, Envconfig)]
+///
+/// `Debug` is implemented manually to redact credentials.
+#[derive(Clone, Envconfig)]
 pub struct CoderConfig {
     #[envconfig(from = "CODER_URL", default = "http://localhost:7080")]
     pub url: String,
@@ -33,11 +35,11 @@ pub struct CoderConfig {
     #[envconfig(from = "CODER_GITHUB_TOKEN")]
     pub github_token: Option<String>,
 
-    #[envconfig(from = "CODER_EXTERNAL_AUTH_0_ID")]
-    pub external_auth_id: Option<String>,
+    #[envconfig(from = "CODER_EXTERNAL_AUTH_0_CLIENT_ID")]
+    pub external_auth_client_id: Option<String>,
 
-    #[envconfig(from = "CODER_EXTERNAL_AUTH_0_SECRET")]
-    pub external_auth_secret: Option<String>,
+    #[envconfig(from = "CODER_EXTERNAL_AUTH_0_CLIENT_SECRET")]
+    pub external_auth_client_secret: Option<String>,
 }
 
 impl CoderConfig {
@@ -47,21 +49,56 @@ impl CoderConfig {
     }
 }
 
+impl fmt::Debug for CoderConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CoderConfig")
+            .field("url", &self.url)
+            .field("session_token", &redact(&self.session_token))
+            .field("admin_email", &self.admin_email)
+            .field("admin_password", &"<redacted>")
+            .field("image_tag", &self.image_tag)
+            .field("github_token", &redact(&self.github_token))
+            .field("external_auth_client_id", &self.external_auth_client_id)
+            .field(
+                "external_auth_client_secret",
+                &redact(&self.external_auth_client_secret),
+            )
+            .finish()
+    }
+}
+
 /// Infrastructure configuration (Redis, A2A relay).
+///
+/// `REDIS_URL` has no compile-time default: callers that accept a fallback use
+/// [`InfraConfig::effective_redis_url`], while strict entry points (e.g. the
+/// harness) require the variable to be explicitly set.
 #[derive(Debug, Clone, Envconfig)]
 pub struct InfraConfig {
-    #[envconfig(from = "REDIS_URL", default = "redis://localhost:6379")]
-    pub redis_url: String,
+    #[envconfig(from = "REDIS_URL")]
+    pub redis_url: Option<String>,
 
     #[envconfig(from = "A2A_RELAY_ADDR", default = "127.0.0.1:3000")]
     pub a2a_relay_addr: String,
 }
 
+impl InfraConfig {
+    /// Redis URL, falling back to the local stack default.
+    pub fn effective_redis_url(&self) -> String {
+        self.redis_url
+            .clone()
+            .unwrap_or_else(|| "redis://localhost:6379".to_string())
+    }
+}
+
 /// OpenFlows tenant / namespace configuration.
-#[derive(Debug, Clone, Envconfig)]
+///
+/// `OPENFLOWS_TENANT` has no compile-time default so that the controller and
+/// harness can detect when it was not explicitly configured. Callers that
+/// accept the namespace fallback use [`TenantConfig::effective_tenant`].
+#[derive(Clone, Envconfig)]
 pub struct TenantConfig {
-    #[envconfig(from = "OPENFLOWS_TENANT", default = "default")]
-    pub tenant: String,
+    #[envconfig(from = "OPENFLOWS_TENANT")]
+    pub tenant: Option<String>,
 
     #[envconfig(from = "OPENFLOWS_TICKET")]
     pub ticket: Option<String>,
@@ -92,6 +129,11 @@ pub struct TenantConfig {
 }
 
 impl TenantConfig {
+    /// Tenant namespace, defaulting to `"default"` when not explicitly set.
+    pub fn effective_tenant(&self) -> &str {
+        self.tenant.as_deref().unwrap_or("default")
+    }
+
     /// Resolve the OpenFlows home directory, defaulting to `~/.openflows`.
     pub fn openflows_home(&self) -> PathBuf {
         if let Some(home) = &self.home {
@@ -104,8 +146,27 @@ impl TenantConfig {
     }
 }
 
+impl fmt::Debug for TenantConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TenantConfig")
+            .field("tenant", &self.tenant)
+            .field("ticket", &self.ticket)
+            .field("role", &self.role)
+            .field("home", &self.home)
+            .field("registry_path", &self.registry_path)
+            .field("registry_json", &self.registry_json)
+            .field("nexus_workspace_id", &self.nexus_workspace_id)
+            .field("nexus_workspace_name", &self.nexus_workspace_name)
+            .field("nexus_api_token", &redact(&self.nexus_api_token))
+            .field("tar", &self.tar)
+            .finish()
+    }
+}
+
 /// GitHub-related configuration.
-#[derive(Debug, Clone, Envconfig)]
+///
+/// `Debug` is implemented manually to redact tokens.
+#[derive(Clone, Envconfig)]
 pub struct GithubConfig {
     #[envconfig(from = "GITHUB_REPOSITORY")]
     pub repository: Option<String>,
@@ -127,6 +188,19 @@ impl GithubConfig {
     }
 }
 
+impl fmt::Debug for GithubConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GithubConfig")
+            .field("repository", &self.repository)
+            .field("token", &redact(&self.token))
+            .field(
+                "personal_access_token",
+                &redact(&self.personal_access_token),
+            )
+            .finish()
+    }
+}
+
 /// Agent/workspace configuration.
 #[derive(Debug, Clone, Envconfig)]
 pub struct AgentConfig {
@@ -136,8 +210,8 @@ pub struct AgentConfig {
     #[envconfig(from = "WORKSPACE_ROOT")]
     pub legacy_workspace_root: Option<String>,
 
-    #[envconfig(from = "USE_AI_GATEWAY", default = "false")]
-    pub use_ai_gateway: bool,
+    #[envconfig(from = "USE_AI_GATEWAY")]
+    pub use_ai_gateway: Option<String>,
 }
 
 impl AgentConfig {
@@ -147,9 +221,16 @@ impl AgentConfig {
             .clone()
             .or_else(|| self.legacy_workspace_root.clone())
     }
+
+    /// Whether the AI gateway is enabled. Accepts the same values the existing
+    /// registry parser does (`"true"` or `"1"`); anything else is treated as
+    /// disabled rather than aborting startup.
+    pub fn use_ai_gateway_enabled(&self) -> bool {
+        matches!(self.use_ai_gateway.as_deref(), Some("true" | "1"))
+    }
 }
 
-/// Aggregated environment configuration loaded once at startup.
+/// Aggregate environment configuration loaded once at startup.
 #[derive(Debug, Clone)]
 pub struct EnvConfig {
     pub coder: CoderConfig,
@@ -157,6 +238,11 @@ pub struct EnvConfig {
     pub tenant: TenantConfig,
     pub github: GithubConfig,
     pub agent: AgentConfig,
+}
+
+/// Redact an optional secret for [`fmt::Debug`] output.
+fn redact(v: &Option<String>) -> Option<&'static str> {
+    v.as_deref().map(|_| "<redacted>")
 }
 
 impl EnvConfig {
@@ -172,7 +258,7 @@ impl EnvConfig {
                  openflows-nexus workspace."
             );
         }
-        if self.tenant.tenant.is_empty() {
+        if self.tenant.tenant.is_none() {
             anyhow::bail!(
                 "OPENFLOWS_TENANT is not set. The Controller must run inside an \
                  openflows-nexus workspace."
@@ -231,10 +317,38 @@ mod tests {
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
-    fn clear(keys: &[&str]) {
-        for k in keys {
-            unsafe {
-                std::env::remove_var(k);
+    /// Snapshot the given variables and restore them on drop so test-runner
+    /// environment changes never leak to other tests.
+    struct EnvGuard {
+        snapshots: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn capture(keys: &[&'static str]) -> Self {
+            let snapshots = keys.iter().map(|k| (*k, std::env::var(k).ok())).collect();
+            EnvGuard { snapshots }
+        }
+
+        fn unset_all(&self) {
+            for (k, _) in &self.snapshots {
+                unsafe {
+                    std::env::remove_var(k);
+                }
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.snapshots {
+                match v {
+                    Some(val) => unsafe {
+                        std::env::set_var(k, val);
+                    },
+                    None => unsafe {
+                        std::env::remove_var(k);
+                    },
+                }
             }
         }
     }
@@ -242,7 +356,7 @@ mod tests {
     #[test]
     fn defaults_applied_when_unset() {
         let _g = ENV_LOCK.lock().unwrap();
-        clear(&[
+        let guard = EnvGuard::capture(&[
             "CODER_URL",
             "CODER_ADMIN_EMAIL",
             "CODER_ADMIN_PASSWORD",
@@ -253,26 +367,33 @@ mod tests {
             "OPENFLOWS_TAR",
             "USE_AI_GATEWAY",
         ]);
+        guard.unset_all();
         let cfg = EnvConfig::from_env().unwrap();
         assert_eq!(cfg.coder.url, "http://localhost:7080");
         assert_eq!(cfg.coder.admin_email, "admin@openflows.dev");
         assert_eq!(cfg.coder.admin_password, "Op3nFl0ws!");
         assert_eq!(cfg.coder.image_tag, "latest");
-        assert_eq!(cfg.infra.redis_url, "redis://localhost:6379");
+        assert_eq!(cfg.infra.effective_redis_url(), "redis://localhost:6379");
         assert_eq!(cfg.infra.a2a_relay_addr, "127.0.0.1:3000");
-        assert_eq!(cfg.tenant.tenant, "default");
+        assert_eq!(cfg.tenant.effective_tenant(), "default");
         assert_eq!(cfg.tenant.tar, "tar");
-        assert!(!cfg.agent.use_ai_gateway);
+        assert!(!cfg.agent.use_ai_gateway_enabled());
     }
 
     #[test]
     fn overrides_from_env() {
         let _g = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::capture(&[
+            "CODER_URL",
+            "REDIS_URL",
+            "OPENFLOWS_TENANT",
+            "USE_AI_GATEWAY",
+        ]);
         for (k, v) in [
             ("CODER_URL", "http://coder.example.com:8080"),
             ("REDIS_URL", "redis://redis.example.com:6379"),
             ("OPENFLOWS_TENANT", "acme"),
-            ("USE_AI_GATEWAY", "true"),
+            ("USE_AI_GATEWAY", "1"),
         ] {
             unsafe {
                 std::env::set_var(k, v);
@@ -280,34 +401,57 @@ mod tests {
         }
         let cfg = EnvConfig::from_env().unwrap();
         assert_eq!(cfg.coder.url, "http://coder.example.com:8080");
-        assert_eq!(cfg.infra.redis_url, "redis://redis.example.com:6379");
-        assert_eq!(cfg.tenant.tenant, "acme");
-        assert!(cfg.agent.use_ai_gateway);
-        clear(&[
-            "CODER_URL",
-            "REDIS_URL",
-            "OPENFLOWS_TENANT",
-            "USE_AI_GATEWAY",
-        ]);
+        assert_eq!(
+            cfg.infra.effective_redis_url(),
+            "redis://redis.example.com:6379"
+        );
+        assert_eq!(cfg.tenant.effective_tenant(), "acme");
+        assert!(cfg.agent.use_ai_gateway_enabled());
     }
 
     #[test]
-    fn parse_error_for_invalid_bool() {
+    fn ai_gateway_accepts_previous_valid_values() {
         let _g = ENV_LOCK.lock().unwrap();
-        unsafe {
-            std::env::set_var("USE_AI_GATEWAY", "not-a-bool");
+        let _guard = EnvGuard::capture(&["USE_AI_GATEWAY"]);
+        for (v, expected) in [
+            ("1", true),
+            ("true", true),
+            ("0", false),
+            ("false", false),
+            ("garbage", false),
+        ] {
+            unsafe {
+                std::env::set_var("USE_AI_GATEWAY", v);
+            }
+            let cfg = EnvConfig::from_env().unwrap();
+            assert_eq!(
+                cfg.agent.use_ai_gateway_enabled(),
+                expected,
+                "USE_AI_GATEWAY={v}"
+            );
         }
-        let err = EnvConfig::from_env().unwrap_err();
-        assert!(format!("{err}").contains("Agent config"));
+    }
+
+    #[test]
+    fn debug_redacts_secrets() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::capture(&["CODER_SESSION_TOKEN", "CODER_ADMIN_PASSWORD"]);
         unsafe {
-            std::env::remove_var("USE_AI_GATEWAY");
+            std::env::set_var("CODER_SESSION_TOKEN", "s3cr3t-token");
+            std::env::set_var("CODER_ADMIN_PASSWORD", "hunter2");
         }
+        let cfg = EnvConfig::from_env().unwrap();
+        let dbg = format!("{:?}", cfg.coder);
+        assert!(dbg.contains("<redacted>"));
+        assert!(!dbg.contains("s3cr3t-token"));
+        assert!(!dbg.contains("hunter2"));
     }
 
     #[test]
     fn openflows_home_defaults_to_tilde() {
         let _g = ENV_LOCK.lock().unwrap();
-        clear(&["OPENFLOWS_HOME", "HOME", "USERPROFILE"]);
+        let guard = EnvGuard::capture(&["OPENFLOWS_HOME", "HOME", "USERPROFILE"]);
+        guard.unset_all();
         let cfg = EnvConfig::from_env().unwrap();
         assert!(cfg
             .tenant

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod agent;
+pub mod env;
 pub mod identity;
 pub mod project;
 pub mod registry;
 pub mod state;
 
 pub use agent::{AgentDef, AgentPermissions};
+pub use env::{AgentConfig, CoderConfig, EnvConfig, GithubConfig, InfraConfig, TenantConfig};
 pub use identity::{AgentIdentity, AgentRole, IdentityManager};
 pub use project::{ProjectConfig, SandboxConfig, PROJECT_CONFIG_FILE};
 pub use registry::{CliBackend, Registry, RegistryEntry, DEFAULT_CLI_ENV_VAR};

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -7,6 +7,7 @@ pub mod state;
 
 pub use agent::{AgentDef, AgentPermissions};
 pub use env::{AgentConfig, CoderConfig, EnvConfig, GithubConfig, InfraConfig, TenantConfig};
+pub use envconfig::Envconfig;
 pub use identity::{AgentIdentity, AgentRole, IdentityManager};
 pub use project::{ProjectConfig, SandboxConfig, PROJECT_CONFIG_FILE};
 pub use registry::{CliBackend, Registry, RegistryEntry, DEFAULT_CLI_ENV_VAR};

--- a/crates/config/tests/env_config_test.rs
+++ b/crates/config/tests/env_config_test.rs
@@ -1,0 +1,87 @@
+//! Integration tests for the centralized `config::env` layer (issue #185).
+
+use config::{CoderConfig, EnvConfig, InfraConfig, TenantConfig};
+use envconfig::Envconfig;
+use std::sync::Mutex;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn clear(keys: &[&str]) {
+    for k in keys {
+        unsafe {
+            std::env::remove_var(k);
+        }
+    }
+}
+
+#[test]
+fn coder_config_parses_defaults_and_overrides() {
+    let _g = ENV_LOCK.lock().unwrap();
+    clear(&[
+        "CODER_URL",
+        "CODER_ADMIN_EMAIL",
+        "CODER_ADMIN_PASSWORD",
+        "CODER_IMAGE_TAG",
+    ]);
+    unsafe {
+        std::env::set_var("CODER_URL", "http://coder.internal:8080");
+    }
+    let cfg = CoderConfig::init_from_env().unwrap();
+    assert_eq!(cfg.url, "http://coder.internal:8080");
+    assert_eq!(cfg.admin_email, "admin@openflows.dev");
+    assert_eq!(cfg.admin_password, "Op3nFl0ws!");
+    assert_eq!(cfg.image_tag, "latest");
+    clear(&[
+        "CODER_URL",
+        "CODER_ADMIN_EMAIL",
+        "CODER_ADMIN_PASSWORD",
+        "CODER_IMAGE_TAG",
+    ]);
+}
+
+#[test]
+fn tenant_openflows_home_uses_default() {
+    let _g = ENV_LOCK.lock().unwrap();
+    clear(&["OPENFLOWS_HOME", "HOME", "USERPROFILE"]);
+    let cfg = TenantConfig::init_from_env().unwrap();
+    let home = cfg.openflows_home();
+    assert!(home.to_string_lossy().ends_with(".openflows"));
+}
+
+#[test]
+fn infra_defaults_applied() {
+    let _g = ENV_LOCK.lock().unwrap();
+    clear(&["REDIS_URL", "A2A_RELAY_ADDR"]);
+    let cfg = InfraConfig::init_from_env().unwrap();
+    assert_eq!(cfg.redis_url, "redis://localhost:6379");
+    assert_eq!(cfg.a2a_relay_addr, "127.0.0.1:3000");
+}
+
+#[test]
+fn env_config_from_env_and_controller_validation() {
+    let _g = ENV_LOCK.lock().unwrap();
+    clear(&[
+        "CODER_SESSION_TOKEN",
+        "OPENFLOWS_TENANT",
+        "GITHUB_REPOSITORY",
+    ]);
+    unsafe {
+        std::env::set_var("CODER_SESSION_TOKEN", "fake-token");
+        std::env::set_var("OPENFLOWS_TENANT", "acme");
+        std::env::set_var("GITHUB_REPOSITORY", "acme/repo");
+    }
+    let env = EnvConfig::from_env().unwrap();
+    assert!(env.validate_controller().is_ok());
+    clear(&[
+        "CODER_SESSION_TOKEN",
+        "OPENFLOWS_TENANT",
+        "GITHUB_REPOSITORY",
+    ]);
+
+    unsafe {
+        std::env::set_var("GITHUB_REPOSITORY", "acme/repo");
+    }
+    let env = EnvConfig::from_env().unwrap();
+    assert!(env.validate_controller().is_err());
+    clear(&["GITHUB_REPOSITORY"]);
+}

--- a/crates/config/tests/env_config_test.rs
+++ b/crates/config/tests/env_config_test.rs
@@ -6,10 +6,38 @@ use std::sync::Mutex;
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
-fn clear(keys: &[&str]) {
-    for k in keys {
-        unsafe {
-            std::env::remove_var(k);
+/// Snapshot the given variables and restore them on drop so test-runner
+/// environment changes never leak to other tests.
+struct EnvGuard {
+    snapshots: Vec<(&'static str, Option<String>)>,
+}
+
+impl EnvGuard {
+    fn capture(keys: &[&'static str]) -> Self {
+        let snapshots = keys.iter().map(|k| (*k, std::env::var(k).ok())).collect();
+        EnvGuard { snapshots }
+    }
+
+    fn unset_all(&self) {
+        for (k, _) in &self.snapshots {
+            unsafe {
+                std::env::remove_var(k);
+            }
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (k, v) in &self.snapshots {
+            match v {
+                Some(val) => unsafe {
+                    std::env::set_var(k, val);
+                },
+                None => unsafe {
+                    std::env::remove_var(k);
+                },
+            }
         }
     }
 }
@@ -17,32 +45,32 @@ fn clear(keys: &[&str]) {
 #[test]
 fn coder_config_parses_defaults_and_overrides() {
     let _g = ENV_LOCK.lock().unwrap();
-    clear(&[
+    let guard = EnvGuard::capture(&[
         "CODER_URL",
         "CODER_ADMIN_EMAIL",
         "CODER_ADMIN_PASSWORD",
         "CODER_IMAGE_TAG",
+        "CODER_EXTERNAL_AUTH_0_CLIENT_ID",
+        "CODER_EXTERNAL_AUTH_0_CLIENT_SECRET",
     ]);
+    guard.unset_all();
     unsafe {
         std::env::set_var("CODER_URL", "http://coder.internal:8080");
+        std::env::set_var("CODER_EXTERNAL_AUTH_0_CLIENT_ID", "github-app");
     }
     let cfg = CoderConfig::init_from_env().unwrap();
     assert_eq!(cfg.url, "http://coder.internal:8080");
     assert_eq!(cfg.admin_email, "admin@openflows.dev");
     assert_eq!(cfg.admin_password, "Op3nFl0ws!");
     assert_eq!(cfg.image_tag, "latest");
-    clear(&[
-        "CODER_URL",
-        "CODER_ADMIN_EMAIL",
-        "CODER_ADMIN_PASSWORD",
-        "CODER_IMAGE_TAG",
-    ]);
+    assert_eq!(cfg.external_auth_client_id.as_deref(), Some("github-app"));
 }
 
 #[test]
 fn tenant_openflows_home_uses_default() {
     let _g = ENV_LOCK.lock().unwrap();
-    clear(&["OPENFLOWS_HOME", "HOME", "USERPROFILE"]);
+    let guard = EnvGuard::capture(&["OPENFLOWS_HOME", "HOME", "USERPROFILE"]);
+    guard.unset_all();
     let cfg = TenantConfig::init_from_env().unwrap();
     let home = cfg.openflows_home();
     assert!(home.to_string_lossy().ends_with(".openflows"));
@@ -51,20 +79,23 @@ fn tenant_openflows_home_uses_default() {
 #[test]
 fn infra_defaults_applied() {
     let _g = ENV_LOCK.lock().unwrap();
-    clear(&["REDIS_URL", "A2A_RELAY_ADDR"]);
+    let guard = EnvGuard::capture(&["REDIS_URL", "A2A_RELAY_ADDR"]);
+    guard.unset_all();
     let cfg = InfraConfig::init_from_env().unwrap();
-    assert_eq!(cfg.redis_url, "redis://localhost:6379");
+    assert_eq!(cfg.redis_url, None);
+    assert_eq!(cfg.effective_redis_url(), "redis://localhost:6379");
     assert_eq!(cfg.a2a_relay_addr, "127.0.0.1:3000");
 }
 
 #[test]
 fn env_config_from_env_and_controller_validation() {
     let _g = ENV_LOCK.lock().unwrap();
-    clear(&[
+    let guard = EnvGuard::capture(&[
         "CODER_SESSION_TOKEN",
         "OPENFLOWS_TENANT",
         "GITHUB_REPOSITORY",
     ]);
+    guard.unset_all();
     unsafe {
         std::env::set_var("CODER_SESSION_TOKEN", "fake-token");
         std::env::set_var("OPENFLOWS_TENANT", "acme");
@@ -72,16 +103,11 @@ fn env_config_from_env_and_controller_validation() {
     }
     let env = EnvConfig::from_env().unwrap();
     assert!(env.validate_controller().is_ok());
-    clear(&[
-        "CODER_SESSION_TOKEN",
-        "OPENFLOWS_TENANT",
-        "GITHUB_REPOSITORY",
-    ]);
+    assert_eq!(env.tenant.effective_tenant(), "acme");
 
-    unsafe {
-        std::env::set_var("GITHUB_REPOSITORY", "acme/repo");
-    }
+    // Without OPENFLOWS_TENANT the controller must fail even though a fallback
+    // "default" namespace exists for unrelated processes.
+    std::env::remove_var("OPENFLOWS_TENANT");
     let env = EnvConfig::from_env().unwrap();
     assert!(env.validate_controller().is_err());
-    clear(&["GITHUB_REPOSITORY"]);
 }

--- a/crates/config/tests/env_config_test.rs
+++ b/crates/config/tests/env_config_test.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the centralized `config::env` layer (issue #185).
 
-use config::{CoderConfig, EnvConfig, InfraConfig, TenantConfig};
+use config::{CoderConfig, EnvConfig, GithubConfig, InfraConfig, TenantConfig};
 use envconfig::Envconfig;
 use std::sync::Mutex;
 
@@ -85,6 +85,21 @@ fn infra_defaults_applied() {
     assert_eq!(cfg.redis_url, None);
     assert_eq!(cfg.effective_redis_url(), "redis://localhost:6379");
     assert_eq!(cfg.a2a_relay_addr, "127.0.0.1:3000");
+}
+
+#[test]
+fn github_config_api_base_default_and_override() {
+    let _g = ENV_LOCK.lock().unwrap();
+    let guard = EnvGuard::capture(&["GITHUB_API_BASE"]);
+    guard.unset_all();
+    let cfg = GithubConfig::init_from_env().unwrap();
+    assert_eq!(cfg.api_base, "https://api.github.com");
+
+    unsafe {
+        std::env::set_var("GITHUB_API_BASE", "https://ghe.example.com/api/v3");
+    }
+    let cfg = GithubConfig::init_from_env().unwrap();
+    assert_eq!(cfg.api_base, "https://ghe.example.com/api/v3");
 }
 
 #[test]

--- a/crates/config/tests/env_config_test.rs
+++ b/crates/config/tests/env_config_test.rs
@@ -20,9 +20,7 @@ impl EnvGuard {
 
     fn unset_all(&self) {
         for (k, _) in &self.snapshots {
-            unsafe {
-                std::env::remove_var(k);
-            }
+            std::env::remove_var(k);
         }
     }
 }
@@ -31,12 +29,8 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (k, v) in &self.snapshots {
             match v {
-                Some(val) => unsafe {
-                    std::env::set_var(k, val);
-                },
-                None => unsafe {
-                    std::env::remove_var(k);
-                },
+                Some(val) => std::env::set_var(k, val),
+                None => std::env::remove_var(k),
             }
         }
     }
@@ -54,14 +48,13 @@ fn coder_config_parses_defaults_and_overrides() {
         "CODER_EXTERNAL_AUTH_0_CLIENT_SECRET",
     ]);
     guard.unset_all();
-    unsafe {
-        std::env::set_var("CODER_URL", "http://coder.internal:8080");
-        std::env::set_var("CODER_EXTERNAL_AUTH_0_CLIENT_ID", "github-app");
-    }
+    std::env::set_var("CODER_URL", "http://coder.internal:8080");
+    std::env::set_var("CODER_EXTERNAL_AUTH_0_CLIENT_ID", "github-app");
     let cfg = CoderConfig::init_from_env().unwrap();
     assert_eq!(cfg.url, "http://coder.internal:8080");
     assert_eq!(cfg.admin_email, "admin@openflows.dev");
-    assert_eq!(cfg.admin_password, "Op3nFl0ws!");
+    assert_eq!(cfg.admin_password, None);
+    assert_eq!(cfg.admin_username, "admin");
     assert_eq!(cfg.image_tag, "latest");
     assert_eq!(cfg.external_auth_client_id.as_deref(), Some("github-app"));
 }
@@ -95,9 +88,7 @@ fn github_config_api_base_default_and_override() {
     let cfg = GithubConfig::init_from_env().unwrap();
     assert_eq!(cfg.api_base, "https://api.github.com");
 
-    unsafe {
-        std::env::set_var("GITHUB_API_BASE", "https://ghe.example.com/api/v3");
-    }
+    std::env::set_var("GITHUB_API_BASE", "https://ghe.example.com/api/v3");
     let cfg = GithubConfig::init_from_env().unwrap();
     assert_eq!(cfg.api_base, "https://ghe.example.com/api/v3");
 }
@@ -111,11 +102,9 @@ fn env_config_from_env_and_controller_validation() {
         "GITHUB_REPOSITORY",
     ]);
     guard.unset_all();
-    unsafe {
-        std::env::set_var("CODER_SESSION_TOKEN", "fake-token");
-        std::env::set_var("OPENFLOWS_TENANT", "acme");
-        std::env::set_var("GITHUB_REPOSITORY", "acme/repo");
-    }
+    std::env::set_var("CODER_SESSION_TOKEN", "fake-token");
+    std::env::set_var("OPENFLOWS_TENANT", "acme");
+    std::env::set_var("GITHUB_REPOSITORY", "acme/repo");
     let env = EnvConfig::from_env().unwrap();
     assert!(env.validate_controller().is_ok());
     assert_eq!(env.tenant.effective_tenant(), "acme");

--- a/crates/github/Cargo.toml
+++ b/crates/github/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 
 [dependencies]
 anyhow        = { workspace = true }
+config        = { version = "0.2.0", path = "../config" }
 serde         = { workspace = true }
 serde_json    = { workspace = true }
 tokio         = { workspace = true, features = ["full"] }

--- a/crates/github/src/rest.rs
+++ b/crates/github/src/rest.rs
@@ -7,6 +7,7 @@
 // via MCP subprocess; this handles direct REST calls for VESSEL's needs.
 
 use anyhow::{Context, Result};
+use config::Envconfig;
 use pocketflow_core::{CiStatus, MergeMethod, MergeResult, PrInfo, PrState};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -18,24 +19,37 @@ use tracing::{debug, info, warn};
 const MAX_RETRIES: u32 = 3;
 const RETRY_BASE_DELAY: Duration = Duration::from_secs(1);
 
-const GITHUB_API_BASE: &str = "https://api.github.com";
+/// Default GitHub REST API base URL, overridable via `GITHUB_API_BASE`.
+const DEFAULT_GITHUB_API_BASE: &str = "https://api.github.com";
 
 /// Direct GitHub REST API client for CI status polling and merge operations.
 #[derive(Clone)]
 pub struct GithubRestClient {
     client: reqwest::Client,
     token: String,
+    api_base: String,
 }
 
 impl GithubRestClient {
     pub fn new(token: impl Into<String>) -> Self {
+        let api_base = config::GithubConfig::init_from_env()
+            .map(|cfg| cfg.api_base)
+            .unwrap_or_else(|_| DEFAULT_GITHUB_API_BASE.to_string());
         Self {
             client: reqwest::Client::builder()
                 .user_agent("AgentFlow-VESSEL/0.1")
                 .build()
                 .expect("Failed to build reqwest client"),
             token: token.into(),
+            api_base,
         }
+    }
+
+    /// Override the GitHub REST API base URL (defaults to
+    /// `https://api.github.com`, configurable via `GITHUB_API_BASE`).
+    pub fn with_api_base(mut self, api_base: impl Into<String>) -> Self {
+        self.api_base = api_base.into();
+        self
     }
 
     fn auth_header(&self) -> String {
@@ -259,7 +273,7 @@ impl GithubRestClient {
     ) -> Result<CiStatus> {
         let url = format!(
             "{}/repos/{}/{}/commits/{}/status",
-            GITHUB_API_BASE, owner, repo, ref_sha
+            self.api_base, owner, repo, ref_sha
         );
         let resp: CombinedStatusResponse = self.get_json(&url).await?;
         Ok(map_status_state(&resp.state))
@@ -275,7 +289,7 @@ impl GithubRestClient {
     ) -> Result<CiStatus> {
         let url = format!(
             "{}/repos/{}/{}/commits/{}/check-suites",
-            GITHUB_API_BASE, owner, repo, ref_sha
+            self.api_base, owner, repo, ref_sha
         );
         let resp: CheckSuitesResponse = self.get_json(&url).await?;
 
@@ -356,7 +370,7 @@ impl GithubRestClient {
     ) -> Result<CiFailureDetail> {
         let url = format!(
             "{}/repos/{}/{}/commits/{}/check-runs",
-            GITHUB_API_BASE, owner, repo, ref_sha
+            self.api_base, owner, repo, ref_sha
         );
         let resp: CheckRunsResponse = match self.get_json(&url).await {
             Ok(r) => r,
@@ -467,7 +481,7 @@ impl GithubRestClient {
     ) -> Result<Vec<CheckAnnotation>> {
         let url = format!(
             "{}/repos/{}/{}/check-runs/{}/annotations",
-            GITHUB_API_BASE, owner, repo, check_run_id
+            self.api_base, owner, repo, check_run_id
         );
         let annotations: Vec<CheckAnnotation> = match self.get_json(&url).await {
             Ok(a) => a,
@@ -489,7 +503,7 @@ impl GithubRestClient {
     ) -> Result<String> {
         let url = format!(
             "{}/repos/{}/{}/commits/{}/check-suites",
-            GITHUB_API_BASE, owner, repo, ref_sha
+            self.api_base, owner, repo, ref_sha
         );
         let resp: serde_json::Value = self.get_json_raw(&url).await?;
 
@@ -528,7 +542,7 @@ impl GithubRestClient {
     ) -> Result<PrInfo> {
         let url = format!(
             "{}/repos/{}/{}/pulls/{}",
-            GITHUB_API_BASE, owner, repo, pr_number
+            self.api_base, owner, repo, pr_number
         );
         let resp: PullRequestResponse = self.get_json(&url).await?;
 
@@ -560,7 +574,7 @@ impl GithubRestClient {
     ) -> Result<MergeResult> {
         let url = format!(
             "{}/repos/{}/{}/pulls/{}/merge",
-            GITHUB_API_BASE, owner, repo, pr_number
+            self.api_base, owner, repo, pr_number
         );
 
         let body = MergeRequestBody {
@@ -588,7 +602,7 @@ impl GithubRestClient {
     ) -> Result<()> {
         let close_url = format!(
             "{}/repos/{}/{}/pulls/{}",
-            GITHUB_API_BASE, owner, repo, pr_number
+            self.api_base, owner, repo, pr_number
         );
         let close_body = serde_json::json!({ "state": "closed" });
 
@@ -597,7 +611,7 @@ impl GithubRestClient {
             Some(text) => {
                 let comment_url = format!(
                     "{}/repos/{}/{}/issues/{}/comments",
-                    GITHUB_API_BASE, owner, repo, pr_number
+                    self.api_base, owner, repo, pr_number
                 );
                 let comment_body = serde_json::json!({ "body": text });
 
@@ -642,7 +656,7 @@ impl GithubRestClient {
 
         let url = format!(
             "{}/repos/{}/{}/contents/.github/workflows",
-            GITHUB_API_BASE, owner, repo
+            self.api_base, owner, repo
         );
 
         let resp = self.send_with_retry(|| self.build_get(&url)).await?;
@@ -684,7 +698,7 @@ impl GithubRestClient {
     async fn content_path_exists(&self, owner: &str, repo: &str, path: &str) -> Result<bool> {
         let url = format!(
             "{}/repos/{}/{}/contents/{}",
-            GITHUB_API_BASE, owner, repo, path
+            self.api_base, owner, repo, path
         );
         let resp = self.send_with_retry(|| self.build_get(&url)).await?;
         let status = resp.status();
@@ -714,7 +728,7 @@ impl GithubRestClient {
     pub async fn list_open_prs(&self, owner: &str, repo: &str) -> Result<Vec<PrInfo>> {
         let url = format!(
             "{}/repos/{}/{}/pulls?state=open&per_page=100",
-            GITHUB_API_BASE, owner, repo
+            self.api_base, owner, repo
         );
         let resp: Vec<PullRequestResponse> = self.get_json(&url).await?;
 
@@ -745,7 +759,7 @@ impl GithubRestClient {
         base: &str,
         body: Option<&str>,
     ) -> Result<u64> {
-        let url = format!("{}/repos/{}/{}/pulls", GITHUB_API_BASE, owner, repo);
+        let url = format!("{}/repos/{}/{}/pulls", self.api_base, owner, repo);
 
         let request_body = serde_json::json!({
             "title": title,
@@ -781,7 +795,7 @@ impl GithubRestClient {
     ) -> Result<Vec<GitHubIssueResponse>> {
         let url = format!(
             "{}/repos/{}/{}/issues?state=open&per_page=100",
-            GITHUB_API_BASE, owner, repo
+            self.api_base, owner, repo
         );
         self.get_json(&url).await
     }
@@ -789,7 +803,7 @@ impl GithubRestClient {
     /// Get the authenticated user's login name using the current token.
     /// Calls GET /user and returns the "login" field.
     pub async fn get_authenticated_user_login(&self) -> Result<String> {
-        let url = format!("{}/user", GITHUB_API_BASE);
+        let url = format!("{}/user", self.api_base);
         let resp = self.send_with_retry(|| self.build_get(&url)).await?;
 
         let status = resp.status();
@@ -825,7 +839,7 @@ impl GithubRestClient {
     ) -> Result<bool> {
         let url = format!(
             "{}/repos/{}/{}/issues/{}/comments?per_page=100",
-            GITHUB_API_BASE, owner, repo, issue_number
+            self.api_base, owner, repo, issue_number
         );
         let comments: Vec<serde_json::Value> = self.get_json(&url).await?;
         Ok(comments.iter().any(|c| {
@@ -846,7 +860,7 @@ impl GithubRestClient {
     ) -> Result<()> {
         let url = format!(
             "{}/repos/{}/{}/issues/{}/comments",
-            GITHUB_API_BASE, owner, repo, issue_number
+            self.api_base, owner, repo, issue_number
         );
         let payload = serde_json::json!({ "body": comment_body });
         let body_bytes = serde_json::to_vec(&payload)?;
@@ -887,7 +901,7 @@ impl GithubRestClient {
     ) -> Result<()> {
         let url = format!(
             "{}/repos/{}/{}/issues/{}",
-            GITHUB_API_BASE, owner, repo, issue_number
+            self.api_base, owner, repo, issue_number
         );
         let body = serde_json::json!({ "assignees": [assignee] });
 
@@ -931,7 +945,7 @@ impl GithubRestClient {
     pub async fn close_issue(&self, owner: &str, repo: &str, issue_number: u64) -> Result<()> {
         let url = format!(
             "{}/repos/{}/{}/issues/{}",
-            GITHUB_API_BASE, owner, repo, issue_number
+            self.api_base, owner, repo, issue_number
         );
         let body = serde_json::json!({ "state": "closed" });
         let resp: serde_json::Value = self.patch_json(&url, &body).await?;
@@ -954,7 +968,7 @@ impl GithubRestClient {
     pub async fn update_branch(&self, owner: &str, repo: &str, pr_number: u64) -> Result<()> {
         let url = format!(
             "{}/repos/{}/{}/pulls/{}/update-branch",
-            GITHUB_API_BASE, owner, repo, pr_number
+            self.api_base, owner, repo, pr_number
         );
 
         let resp = self.send_with_retry(|| self.build_put(&url, &[])).await?;
@@ -983,7 +997,7 @@ impl GithubRestClient {
     ) -> Result<Vec<String>> {
         let url = format!(
             "{}/repos/{}/{}/pulls/{}/files",
-            GITHUB_API_BASE, owner, repo, pr_number
+            self.api_base, owner, repo, pr_number
         );
 
         let resp: Vec<PrFileResponse> = self.get_json(&url).await?;
@@ -1009,7 +1023,7 @@ impl GithubRestClient {
     ) -> Result<Vec<(String, String)>> {
         let url = format!(
             "{}/repos/{}/{}/actions/runs?head_sha={}&status=failure&per_page=10",
-            GITHUB_API_BASE, owner, repo, head_sha
+            self.api_base, owner, repo, head_sha
         );
 
         let runs_resp: WorkflowRunsResponse = match self.get_json(&url).await {
@@ -1027,7 +1041,7 @@ impl GithubRestClient {
 
             let jobs_url = format!(
                 "{}/repos/{}/{}/actions/runs/{}/jobs?per_page=50",
-                GITHUB_API_BASE, owner, repo, run.id
+                self.api_base, owner, repo, run.id
             );
 
             let jobs_resp: WorkflowJobsResponse = match self.get_json(&jobs_url).await {
@@ -1047,7 +1061,7 @@ impl GithubRestClient {
 
                 let log_url = format!(
                     "{}/repos/{}/{}/actions/jobs/{}/logs",
-                    GITHUB_API_BASE, owner, repo, job.id
+                    self.api_base, owner, repo, job.id
                 );
 
                 match self.get_text(&log_url).await {

--- a/crates/github/src/rest.rs
+++ b/crates/github/src/rest.rs
@@ -19,9 +19,6 @@ use tracing::{debug, info, warn};
 const MAX_RETRIES: u32 = 3;
 const RETRY_BASE_DELAY: Duration = Duration::from_secs(1);
 
-/// Default GitHub REST API base URL, overridable via `GITHUB_API_BASE`.
-const DEFAULT_GITHUB_API_BASE: &str = "https://api.github.com";
-
 /// Direct GitHub REST API client for CI status polling and merge operations.
 #[derive(Clone)]
 pub struct GithubRestClient {
@@ -32,9 +29,11 @@ pub struct GithubRestClient {
 
 impl GithubRestClient {
     pub fn new(token: impl Into<String>) -> Self {
+        // The GitHub REST API base is configured via `GITHUB_API_BASE`, whose
+        // default (`https://api.github.com`) lives in `config::GithubConfig`.
         let api_base = config::GithubConfig::init_from_env()
             .map(|cfg| cfg.api_base)
-            .unwrap_or_else(|_| DEFAULT_GITHUB_API_BASE.to_string());
+            .unwrap_or_else(|_| "https://api.github.com".to_string());
         Self {
             client: reqwest::Client::builder()
                 .user_agent("AgentFlow-VESSEL/0.1")
@@ -43,13 +42,6 @@ impl GithubRestClient {
             token: token.into(),
             api_base,
         }
-    }
-
-    /// Override the GitHub REST API base URL (defaults to
-    /// `https://api.github.com`, configurable via `GITHUB_API_BASE`).
-    pub fn with_api_base(mut self, api_base: impl Into<String>) -> Self {
-        self.api_base = api_base.into();
-        self
     }
 
     fn auth_header(&self) -> String {

--- a/crates/openflows-harness/src/a2a_client.rs
+++ b/crates/openflows-harness/src/a2a_client.rs
@@ -30,8 +30,9 @@ impl A2AClient {
     /// workspace that omits `A2A_RELAY_ADDR` would otherwise silently target
     /// its own interface (issue #143 / PR review), so it warns here.
     pub fn new(pair_id: String, role: String) -> Result<Self> {
-        let relay_addr = match std::env::var("A2A_RELAY_ADDR") {
-            Ok(addr) if !addr.trim().is_empty() => addr,
+        let env = config::EnvConfig::from_env()?;
+        let relay_addr = match env.infra.a2a_relay_addr.as_str() {
+            addr if !addr.trim().is_empty() => addr.to_string(),
             _ => {
                 warn!(
                     "A2A_RELAY_ADDR is not set; defaulting to 127.0.0.1:3000. \

--- a/crates/openflows-harness/src/main.rs
+++ b/crates/openflows-harness/src/main.rs
@@ -233,8 +233,15 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     let env = config::EnvConfig::from_env().context("failed to load environment configuration")?;
-    let redis_url = env.infra.redis_url.clone();
-    let tenant = env.tenant.tenant.clone();
+    let redis_url = env
+        .infra
+        .redis_url
+        .clone()
+        .context("REDIS_URL is not set. This must be injected by the workspace template.")?;
+    let tenant =
+        env.tenant.tenant.clone().context(
+            "OPENFLOWS_TENANT is not set. This must be injected by the workspace template.",
+        )?;
     let ticket =
         env.tenant.ticket.clone().context(
             "OPENFLOWS_TICKET is not set. This must be injected by the workspace template.",

--- a/crates/openflows-harness/src/main.rs
+++ b/crates/openflows-harness/src/main.rs
@@ -221,13 +221,6 @@ enum VerifyAction {
     },
 }
 
-fn require_env(name: &str) -> Result<String> {
-    std::env::var(name).context(format!(
-        "{} is not set. This must be injected by the workspace template.",
-        name
-    ))
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -238,10 +231,18 @@ async fn main() -> Result<()> {
         .init();
 
     let cli = Cli::parse();
-    let redis_url = require_env("REDIS_URL")?;
-    let tenant = require_env("OPENFLOWS_TENANT")?;
-    let ticket = require_env("OPENFLOWS_TICKET")?;
-    let role = require_env("OPENFLOWS_ROLE")?;
+
+    let env = config::EnvConfig::from_env().context("failed to load environment configuration")?;
+    let redis_url = env.infra.redis_url.clone();
+    let tenant = env.tenant.tenant.clone();
+    let ticket =
+        env.tenant.ticket.clone().context(
+            "OPENFLOWS_TICKET is not set. This must be injected by the workspace template.",
+        )?;
+    let role =
+        env.tenant.role.clone().context(
+            "OPENFLOWS_ROLE is not set. This must be injected by the workspace template.",
+        )?;
 
     let store = store::HarnessStore::new(&redis_url, &tenant).await?;
 

--- a/crates/openflows-harness/src/store.rs
+++ b/crates/openflows-harness/src/store.rs
@@ -634,7 +634,12 @@ impl HarnessStore {
             std::env::var("CODER_WORKSPACE_ID").unwrap_or_else(|_| "unknown".to_string());
 
         // Get tenant for Redis namespacing
-        let tenant = std::env::var("OPENFLOWS_TENANT").context("OPENFLOWS_TENANT not set")?;
+        let env = config::EnvConfig::from_env()?;
+        let tenant = env
+            .tenant
+            .tenant
+            .clone()
+            .context("OPENFLOWS_TENANT not set")?;
 
         println!(
             "✓ Forge verify executor ready (workspace: {}, ticket: {})",

--- a/crates/pocketflow-core/Cargo.toml
+++ b/crates/pocketflow-core/Cargo.toml
@@ -13,6 +13,7 @@ serde       = { workspace = true }
 serde_json  = { workspace = true }
 fred        = { workspace = true }
 tracing     = { workspace = true }
+config      = { version = "0.2.0", path = "../config" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/pocketflow-core/src/store.rs
+++ b/crates/pocketflow-core/src/store.rs
@@ -177,9 +177,13 @@ impl SharedStore {
     /// Redis backend with explicit or derived tenant.
     /// If tenant is None, reads from OPENFLOWS_TENANT env var.
     pub async fn new_redis_with_tenant(url: &str, tenant: Option<String>) -> Result<Self> {
-        let resolved_tenant = tenant
-            .or_else(|| std::env::var("OPENFLOWS_TENANT").ok())
-            .unwrap_or_else(|| "default".to_string());
+        let resolved_tenant = if let Some(t) = tenant {
+            t
+        } else {
+            config::EnvConfig::from_env()
+                .map(|e| e.tenant.effective_tenant().to_string())
+                .unwrap_or_else(|_| "default".to_string())
+        };
 
         Ok(Self {
             backend: Backend::Redis(Arc::new(RedisBackend::new(url).await?)),

--- a/docs/env-config-audit.md
+++ b/docs/env-config-audit.md
@@ -1,0 +1,92 @@
+# Environment Configuration Audit
+
+Issue #185 — centralize environment configuration with `envconfig`.
+
+This document inventories every environment variable read by the Rust
+workspace, classifies it, and records the recommended action. It accompanies
+the new centralized `crates/config/src/env.rs` layer.
+
+## Classification key
+
+| Tag | Meaning |
+|---|---|
+| `in-use` | Read by Rust code and needed at runtime. |
+| `required` | `in-use` and mandatory (startup fails if missing) — no default. |
+| `duplicated` | Same value defaulted/read inline in more than one crate; the inline default should move to the config layer. |
+| `legacy-alias` | Two env vars mean the same thing; one should be canonical, the other kept as a deprecated alias. |
+| `stale` / `unused-in-rust` | Only referenced by `.env.example`/docker-compose, never read by Rust. |
+| `internal` | Set by the code itself (`std::env::set_var`) and consumed internally; not user configuration. |
+
+## Inventory
+
+| Variable | Files (Rust) | Classification | Action |
+|---|---|---|---|
+| `CODER_URL` | coder-client, agent-sentinel, agent-nexus, agent-forge, binary | in-use · duplicated | Centralize default (`http://localhost:7080`) in `CoderConfig.url` |
+| `CODER_SESSION_TOKEN` | coder-client, sentinel, nexus, forge, vessel, binary | required | `CoderConfig.session_token`; required in controller |
+| `CODER_API_TOKEN` | sentinel, nexus, forge, vessel, binary/doctor | legacy-alias | **Excluded from centralized layer** (duplicate of `CODER_SESSION_TOKEN`); callers keep their inline fallback |
+| `CODER_ADMIN_USERNAME` | coder-client/bootstrap | stale | **Removed** — Coder signs in by email, not username |
+| `CODER_ADMIN_EMAIL` | coder-client/bootstrap | in-use | `CoderConfig.admin_email` (default `admin@openflows.dev`) |
+| `CODER_ADMIN_PASSWORD` | coder-client/bootstrap | in-use | `CoderConfig.admin_password` (default `Op3nFl0ws!`) |
+| `CODER_GITHUB_TOKEN` | agent-vessel/types | in-use | `CoderConfig.github_token` |
+| `CODER_IMAGE_TAG` | binary/doctor | in-use | `CoderConfig.image_tag` (default `latest`) |
+| `CODER_TRANSPORT_VERBOSE` | provisioner/transport | confusing | **Excluded from centralized layer** |
+| `CODER_WORKSPACE_ID` | openflows-harness/store | confusing | **Excluded from centralized layer** (read inline with default only) |
+| `CODER_EXTERNAL_AUTH_0_ID` | binary/doctor | in-use | `CoderConfig.external_auth_id` |
+| `CODER_EXTERNAL_AUTH_0_SECRET` | binary/doctor | in-use | `CoderConfig.external_auth_secret` |
+| `REDIS_URL` | binary, debug, doctor | in-use · duplicated | `InfraConfig.redis_url` (default `redis://localhost:6379`) |
+| `A2A_RELAY_ADDR` | agent-nexus/a2a, harness/a2a_client | in-use · duplicated | `InfraConfig.a2a_relay_addr` (default `127.0.0.1:3000`) |
+| `OPENFLOWS_TENANT` | coder-client, pocketflow-core, nexus, harness, binary | required · duplicated | `TenantConfig.tenant` (default `default`; required in controller) |
+| `OPENFLOWS_TICKET` | openflows-harness | required | `TenantConfig.ticket` |
+| `OPENFLOWS_ROLE` | openflows-harness | required | `TenantConfig.role` |
+| `OPENFLOWS_HOME` | agent-vessel, binary/orchestration | in-use | `TenantConfig.home` (default `~/.openflows`) |
+| `OPENFLOWS_REGISTRY_PATH` | coder-client, nexus, binary | in-use · internal | `TenantConfig.registry_path` |
+| `OPENFLOWS_REGISTRY_JSON` | coder-client, nexus, binary | in-use · internal | `TenantConfig.registry_json` |
+| `OPENFLOWS_NEXUS_WORKSPACE_ID` | coder-client | in-use · internal | `TenantConfig.nexus_workspace_id` |
+| `OPENFLOWS_NEXUS_WORKSPACE_NAME` | coder-client | in-use · internal | `TenantConfig.nexus_workspace_name` |
+| `OPENFLOWS_NEXUS_API_TOKEN` | coder-client | in-use · legacy-alias | `TenantConfig.nexus_api_token`; reconcile with `NEXUS_CODER_API_TOKEN` |
+| `NEXUS_CODER_API_TOKEN` | coder-client | legacy-alias | Merge into `OPENFLOWS_NEXUS_API_TOKEN` |
+| `OPENFLOWS_TAR` | coder-client/build.rs | in-use | `TenantConfig.tar` (default `tar`) |
+| `ARTIFACTS_DIR` | agent-nexus, binary | in-use · internal | `TenantConfig`/`AgentConfig` |
+| `AGENTFLOW_WORKSPACE_ROOT` | agent-lore, agent-vessel | in-use · legacy-alias | `AgentConfig.workspace_root` (canonical) |
+| `WORKSPACE_ROOT` | agent-nexus, agent-vessel | legacy-alias | `AgentConfig.legacy_workspace_root` (deprecated) |
+| `HOME` / `USERPROFILE` | coder-client, nexus, vessel, binary | in-use (platform) | Use `dirs` semantics / `TenantConfig.openflows_home()` |
+| `GITHUB_TOKEN` | agent-nexus | in-use | `GithubConfig.token` |
+| `GITHUB_REPOSITORY` | coder-client, nexus, binary | required | `GithubConfig.repository` |
+| `GITHUB_PERSONAL_ACCESS_TOKEN` | coder-client, agent-lore, vessel, config | required | `GithubConfig.personal_access_token`; `effective_token()` |
+| `USE_AI_GATEWAY` | config/registry | in-use | `AgentConfig.use_ai_gateway` |
+| `DEFAULT_CLI` | config/registry | in-use | keep (registry-specific) |
+| `SLACK_WEBHOOK_URL` | notifier | in-use | **Excluded from centralized layer** (notifier config removed) |
+| `DISCORD_WEBHOOK_URL` | notifier | in-use | **Excluded from centralized layer** (notifier config removed) |
+| `WHATSAPP_ACCOUNT_SID` | notifier | in-use | **Excluded from centralized layer** (notifier config removed) |
+| `WHATSAPP_API_KEY` | notifier | legacy-alias | **Excluded from centralized layer** (notifier config removed) |
+| `WHATSAPP_AUTH_TOKEN` | notifier | in-use | **Excluded from centralized layer** (notifier config removed) |
+| `WHATSAPP_FROM_PHONE` | notifier | in-use | **Excluded from centralized layer** (notifier config removed) |
+| `WHATSAPP_TO_PHONE` | notifier | in-use | **Excluded from centralized layer** (notifier config removed) |
+| `WHATSAPP_PHONE_NUMBER` | notifier | legacy-alias | **Excluded from centralized layer** (notifier config removed) |
+| `TF_VAR_dev_binary_host_path` | coder-client | internal | keep (set by code for terraform) |
+| `CODER_PG_PASSWORD` | — (docker-compose only) | stale / unused-in-rust | remove from Rust docs; keep in compose |
+| `CODER_PORT`, `CODER_INTERNAL_PORT` | — (docker-compose only) | stale / unused-in-rust | remove from Rust docs |
+| `CODER_OAUTH2_GITHUB_ALLOW_SIGNUPS` | — (docker-compose only) | stale / unused-in-rust | remove from Rust docs |
+| `CODER_ACCESS_URL` | — (compose/scripts only) | stale / unused-in-rust | — |
+
+## Removed / excluded from the centralized layer
+
+The following config was intentionally left out of `config::env` in issue #185:
+
+- **Notifier config** — `SLACK_WEBHOOK_URL`, `DISCORD_WEBHOOK_URL`, and all
+  `WHATSAPP_*` vars: notifier config and its struct were removed entirely.
+- **`CODER_API_TOKEN`** — duplicate of `CODER_SESSION_TOKEN`; excluded (existing
+  callers keep their inline fallback).
+- **`CODER_ADMIN_USERNAME`** — removed; Coder signs in by email, not username.
+- **`CODER_TRANSPORT_VERBOSE`** — excluded (inline read in provisioner only).
+- **`CODER_WORKSPACE_ID`** — excluded (inline read with default only).
+
+## Recommended cleanups (non-blocking, follow-up)
+
+1. Promote `AGENTFLOW_WORKSPACE_ROOT` as canonical; drop `WORKSPACE_ROOT` over
+   time (kept only as a deprecated alias for now).
+2. Reconcile `OPENFLOWS_NEXUS_API_TOKEN` vs `NEXUS_CODER_API_TOKEN`.
+3. Remove docker-compose-only vars from Rust-facing documentation.
+4. Migrate remaining inline `std::env::var` reads in the agent crates onto the
+   centralized accessors (`CoderConfig`, `InfraConfig`, `TenantConfig`,
+   `GithubConfig`, `AgentConfig`).

--- a/docs/env-config-audit.md
+++ b/docs/env-config-audit.md
@@ -33,6 +33,10 @@ the new centralized `crates/config/src/env.rs` layer.
 | `CODER_WORKSPACE_ID` | openflows-harness/store | confusing | **Excluded from centralized layer** (read inline with default only) |
 | `CODER_EXTERNAL_AUTH_0_CLIENT_ID` | .env.example, docker-compose | in-use | `CoderConfig.external_auth_client_id` (canonical; `CODER_EXTERNAL_AUTH_0_ID` remains an inline read in binary/doctor) |
 | `CODER_EXTERNAL_AUTH_0_CLIENT_SECRET` | .env.example, docker-compose | in-use | `CoderConfig.external_auth_client_secret` (canonical; `CODER_EXTERNAL_AUTH_0_SECRET` remains an inline read in binary/doctor) |
+| `CODER_EXTERNAL_AUTH_0_ID` | .env.example, binary/doctor | in-use · inline | OIDC external-auth provider ID (inline read; not centralized) |
+| `CODER_EXTERNAL_AUTH_0_TYPE` | .env.example | in-use · Coder-side | External-auth provider type (e.g. `github`); Coder config, not centralized |
+| `CODER_EXTERNAL_AUTH_0_SCOPES` | .env.example | in-use · Coder-side | External-auth requested scopes (e.g. `repo`); Coder config, not centralized |
+| `CODER_EXTERNAL_AUTH_0_APP_INSTALL_URL` | .env.example | in-use · Coder-side | GitHub App install URL surfaced in the Coder UI; not centralized |
 | `REDIS_URL` | binary, debug, doctor, harness | required (harness) | `InfraConfig.redis_url` (Option; `effective_redis_url()` default `redis://localhost:6379`; harness requires it) |
 | `A2A_RELAY_ADDR` | agent-nexus/a2a, harness/a2a_client | in-use · duplicated | `InfraConfig.a2a_relay_addr` (default `127.0.0.1:3000`) |
 | `OPENFLOWS_TENANT` | coder-client, pocketflow-core, nexus, harness, binary | required (controller/harness) | `TenantConfig.tenant` (Option; `effective_tenant()` default `default`; required in controller) |
@@ -54,9 +58,9 @@ the new centralized `crates/config/src/env.rs` layer.
 | `GITHUB_REPOSITORY` | coder-client, nexus, binary | required | `GithubConfig.repository` |
 | `GITHUB_PERSONAL_ACCESS_TOKEN` | coder-client, agent-lore, vessel, config | required | `GithubConfig.personal_access_token`; `effective_token()` |
 | `GITHUB_API_BASE` | github/rest | in-use | `GithubConfig.api_base` (default `https://api.github.com`); `GithubRestClient::new` resolves it via `GithubConfig::init_from_env()` |
-| `USE_AI_GATEWAY` | config/registry | in-use | `AgentConfig.use_ai_gateway` (bool) |
+| `USE_AI_GATEWAY` | config/registry | in-use | `AgentConfig.use_ai_gateway` (lenient string; `"true"`/`"1"` enabled via `use_ai_gateway_enabled()`, consistent with `registry::resolve_ai_gateway_enabled`) |
 | `ROLE` | coder-client/bootstrap | in-use | `AgentConfig.role` |
-| `OPENFLOWS_CREATE_NEXUS_WORKSPACE` | coder-client/bootstrap | in-use | `AgentConfig.create_nexus_workspace` (bool; default enabled) |
+| `OPENFLOWS_CREATE_NEXUS_WORKSPACE` | coder-client/bootstrap | in-use | `AgentConfig.create_nexus_workspace_enabled()` (lenient string; default enabled, only `"false"` disables) |
 | `DEFAULT_CLI` | config/registry | in-use | keep (registry-specific) |
 | `SLACK_WEBHOOK_URL` | notifier | in-use | **Excluded from centralized layer** (notifier config removed) |
 | `DISCORD_WEBHOOK_URL` | notifier | in-use | **Excluded from centralized layer** (notifier config removed) |

--- a/docs/env-config-audit.md
+++ b/docs/env-config-audit.md
@@ -31,11 +31,11 @@ the new centralized `crates/config/src/env.rs` layer.
 | `CODER_IMAGE_TAG` | binary/doctor | in-use | `CoderConfig.image_tag` (default `latest`) |
 | `CODER_TRANSPORT_VERBOSE` | provisioner/transport | confusing | **Excluded from centralized layer** |
 | `CODER_WORKSPACE_ID` | openflows-harness/store | confusing | **Excluded from centralized layer** (read inline with default only) |
-| `CODER_EXTERNAL_AUTH_0_ID` | binary/doctor | in-use | `CoderConfig.external_auth_id` |
-| `CODER_EXTERNAL_AUTH_0_SECRET` | binary/doctor | in-use | `CoderConfig.external_auth_secret` |
-| `REDIS_URL` | binary, debug, doctor | in-use · duplicated | `InfraConfig.redis_url` (default `redis://localhost:6379`) |
+| `CODER_EXTERNAL_AUTH_0_CLIENT_ID` | .env.example, docker-compose | in-use | `CoderConfig.external_auth_client_id` (canonical; `CODER_EXTERNAL_AUTH_0_ID` remains an inline read in binary/doctor) |
+| `CODER_EXTERNAL_AUTH_0_CLIENT_SECRET` | .env.example, docker-compose | in-use | `CoderConfig.external_auth_client_secret` (canonical; `CODER_EXTERNAL_AUTH_0_SECRET` remains an inline read in binary/doctor) |
+| `REDIS_URL` | binary, debug, doctor, harness | required (harness) | `InfraConfig.redis_url` (Option; `effective_redis_url()` default `redis://localhost:6379`; harness requires it) |
 | `A2A_RELAY_ADDR` | agent-nexus/a2a, harness/a2a_client | in-use · duplicated | `InfraConfig.a2a_relay_addr` (default `127.0.0.1:3000`) |
-| `OPENFLOWS_TENANT` | coder-client, pocketflow-core, nexus, harness, binary | required · duplicated | `TenantConfig.tenant` (default `default`; required in controller) |
+| `OPENFLOWS_TENANT` | coder-client, pocketflow-core, nexus, harness, binary | required (controller/harness) | `TenantConfig.tenant` (Option; `effective_tenant()` default `default`; required in controller) |
 | `OPENFLOWS_TICKET` | openflows-harness | required | `TenantConfig.ticket` |
 | `OPENFLOWS_ROLE` | openflows-harness | required | `TenantConfig.role` |
 | `OPENFLOWS_HOME` | agent-vessel, binary/orchestration | in-use | `TenantConfig.home` (default `~/.openflows`) |

--- a/docs/env-config-audit.md
+++ b/docs/env-config-audit.md
@@ -24,9 +24,9 @@ the new centralized `crates/config/src/env.rs` layer.
 | `CODER_URL` | coder-client, agent-sentinel, agent-nexus, agent-forge, binary | in-use · duplicated | Centralize default (`http://localhost:7080`) in `CoderConfig.url` |
 | `CODER_SESSION_TOKEN` | coder-client, sentinel, nexus, forge, vessel, binary | required | `CoderConfig.session_token`; required in controller |
 | `CODER_API_TOKEN` | sentinel, nexus, forge, vessel, binary/doctor | legacy-alias | **Excluded from centralized layer** (duplicate of `CODER_SESSION_TOKEN`); callers keep their inline fallback |
-| `CODER_ADMIN_USERNAME` | coder-client/bootstrap | stale | **Removed** — Coder signs in by email, not username |
+| `CODER_ADMIN_USERNAME` | coder-client/bootstrap | in-use | `CoderConfig.admin_username` (default `admin`) |
 | `CODER_ADMIN_EMAIL` | coder-client/bootstrap | in-use | `CoderConfig.admin_email` (default `admin@openflows.dev`) |
-| `CODER_ADMIN_PASSWORD` | coder-client/bootstrap | in-use | `CoderConfig.admin_password` (default `Op3nFl0ws!`) |
+| `CODER_ADMIN_PASSWORD` | coder-client/bootstrap | in-use | `CoderConfig.admin_password` (Option; no baked-in default — bootstrapper applies a secure fallback only when absent/weak) |
 | `CODER_GITHUB_TOKEN` | agent-vessel/types | in-use | `CoderConfig.github_token` |
 | `CODER_IMAGE_TAG` | binary/doctor | in-use | `CoderConfig.image_tag` (default `latest`) |
 | `CODER_TRANSPORT_VERBOSE` | provisioner/transport | confusing | **Excluded from centralized layer** |
@@ -54,7 +54,9 @@ the new centralized `crates/config/src/env.rs` layer.
 | `GITHUB_REPOSITORY` | coder-client, nexus, binary | required | `GithubConfig.repository` |
 | `GITHUB_PERSONAL_ACCESS_TOKEN` | coder-client, agent-lore, vessel, config | required | `GithubConfig.personal_access_token`; `effective_token()` |
 | `GITHUB_API_BASE` | github/rest | in-use | `GithubConfig.api_base` (default `https://api.github.com`); `GithubRestClient::new` resolves it via `GithubConfig::init_from_env()` |
-| `USE_AI_GATEWAY` | config/registry | in-use | `AgentConfig.use_ai_gateway` |
+| `USE_AI_GATEWAY` | config/registry | in-use | `AgentConfig.use_ai_gateway` (bool) |
+| `ROLE` | coder-client/bootstrap | in-use | `AgentConfig.role` |
+| `OPENFLOWS_CREATE_NEXUS_WORKSPACE` | coder-client/bootstrap | in-use | `AgentConfig.create_nexus_workspace` (bool; default enabled) |
 | `DEFAULT_CLI` | config/registry | in-use | keep (registry-specific) |
 | `SLACK_WEBHOOK_URL` | notifier | in-use | **Excluded from centralized layer** (notifier config removed) |
 | `DISCORD_WEBHOOK_URL` | notifier | in-use | **Excluded from centralized layer** (notifier config removed) |
@@ -78,7 +80,6 @@ The following config was intentionally left out of `config::env` in issue #185:
   `WHATSAPP_*` vars: notifier config and its struct were removed entirely.
 - **`CODER_API_TOKEN`** — duplicate of `CODER_SESSION_TOKEN`; excluded (existing
   callers keep their inline fallback).
-- **`CODER_ADMIN_USERNAME`** — removed; Coder signs in by email, not username.
 - **`CODER_TRANSPORT_VERBOSE`** — excluded (inline read in provisioner only).
 - **`CODER_WORKSPACE_ID`** — excluded (inline read with default only).
 

--- a/docs/env-config-audit.md
+++ b/docs/env-config-audit.md
@@ -53,6 +53,7 @@ the new centralized `crates/config/src/env.rs` layer.
 | `GITHUB_TOKEN` | agent-nexus | in-use | `GithubConfig.token` |
 | `GITHUB_REPOSITORY` | coder-client, nexus, binary | required | `GithubConfig.repository` |
 | `GITHUB_PERSONAL_ACCESS_TOKEN` | coder-client, agent-lore, vessel, config | required | `GithubConfig.personal_access_token`; `effective_token()` |
+| `GITHUB_API_BASE` | github/rest | in-use | `GithubConfig.api_base` (default `https://api.github.com`); `GithubRestClient::new` resolves it via `GithubConfig::init_from_env()` |
 | `USE_AI_GATEWAY` | config/registry | in-use | `AgentConfig.use_ai_gateway` |
 | `DEFAULT_CLI` | config/registry | in-use | keep (registry-specific) |
 | `SLACK_WEBHOOK_URL` | notifier | in-use | **Excluded from centralized layer** (notifier config removed) |
@@ -87,6 +88,12 @@ The following config was intentionally left out of `config::env` in issue #185:
    time (kept only as a deprecated alias for now).
 2. Reconcile `OPENFLOWS_NEXUS_API_TOKEN` vs `NEXUS_CODER_API_TOKEN`.
 3. Remove docker-compose-only vars from Rust-facing documentation.
-4. Migrate remaining inline `std::env::var` reads in the agent crates onto the
+4. ~~Migrate remaining inline `std::env::var` reads in the agent crates onto the
    centralized accessors (`CoderConfig`, `InfraConfig`, `TenantConfig`,
-   `GithubConfig`, `AgentConfig`).
+   `GithubConfig`, `AgentConfig`).~~ **Done** — all remaining reads that belong to
+   a centralized variable now route through the `config::env` structs. The only
+   reads left are documented exclusions (e.g. `CODER_API_TOKEN`,
+   `CODER_TRANSPORT_VERBOSE`, `CODER_WORKSPACE_ID`, notifier vars, `ARTIFACTS_DIR`,
+   `TF_VAR_dev_binary_host_path`, `HOME`/`USERPROFILE`), dynamic keys, and
+   `OPENFLOWS_TAR` in `coder-client/build.rs` (build scripts can only use
+   `[build-dependencies]`, so the central `config` crate is not reachable there).


### PR DESCRIPTION
Closes #185

## Summary

Centralize the scattered, inline `std::env::var(...)` configuration reads into a type-safe, validated config layer in the existing `crates/config` crate, built on `envconfig`.

## Changes

- **`crates/config/src/env.rs`** (new): `EnvConfig` aggregating `CoderConfig`, `InfraConfig`, `TenantConfig`, `GithubConfig`, and `AgentConfig` — all `envconfig`-derived with safe defaults (e.g. `CODER_URL`, `REDIS_URL`, `OPENFLOWS_TENANT`, admin defaults) and clear startup validation via `validate_controller()`.
- **Workspace deps**: added `envconfig = "0.11"` and wired it into the `config` crate.
- **Startup wiring**:
  - `binary/src/bin/agentflow.rs` — controller loads `EnvConfig::from_env()` once and validates instead of inline reads.
  - `crates/openflows-harness/src/main.rs` — harness loads config centrally (values still required, no defaults for `REDIS_URL`/`TICKET`/`ROLE`/`TENANT`).
- **Tests**: `crates/config/tests/env_config_test.rs` plus in-module tests covering defaults, overrides, parse failures, and controller validation.
- **Audit**: `docs/env-config-audit.md` — inventory classifying every env var as in-use / required / duplicated / legacy-alias / stale.
- **`.env.example`** — trimmed to the centralized variable set with max one-line comments per variable.

## Excluded from the centralized layer (per review)

- Notifier config (`SLACK_WEBHOOK_URL`, `DISCORD_WEBHOOK_URL`, all `WHATSAPP_*`)
- `CODER_API_TOKEN` (duplicate of `CODER_SESSION_TOKEN`)
- `CODER_ADMIN_USERNAME` (Coder signs in by email, not username)
- `CODER_TRANSPORT_VERBOSE`
- `CODER_WORKSPACE_ID`

## Validation

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo nextest run --workspace` — 171 tests pass ✅
- `cargo machete` ✅
