### PR TITLE
feat(lifecycle-hooks): add hook-driven orchestration, PAT git, and recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,21 @@ CODER_SESSION_TOKEN=your_token_here
 # CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=your_github_app_client_secret
 # CODER_EXTERNAL_AUTH_0_SCOPES=repo
 
+# ── Coder Agent Lifecycle Hooks (EXPERIMENTAL) ─────────────────────────────
+# Enables OpenFlows as the CONSUMER of Coder's experimental
+# agent-lifecycle-hooks webhook. Set these on the Coder server to emit events:
+#   CODER_EXPERIMENTS=agent-lifecycle-hooks
+#   CODER_CHAT_HOOK_URL=http://<openflows-host>:3001/hooks/chat
+#   CODER_CHAT_HOOK_SECRET=<>=32 random bytes>
+# On the OpenFlows controller side (this file):
+#   CODER_CHAT_HOOK_URL=http://<openflows-host>:3001/hooks/chat
+#   CODER_CHAT_HOOK_SECRET=<the same 32+ byte secret>
+# OpenFlows then verifies the HS256 JWT and records every lifecycle event
+# (session_start / user_prompt_submit / pre_tool_use / post_tool_use /
+# pre_compact / post_compact / stop) to a tenant-scoped Redis audit trail at
+# ns:{tenant}:_hook_events_tail.
+# OPENFLOWS_HOOK_ADDR=127.0.0.1:3001
+
 # ── Infrastructure ────────────────────────────────────────────────────────
 # Only set if you host Redis or Coder elsewhere than the local stack.
 # REDIS_URL=redis://localhost:6379

--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,7 @@ OPENFLOWS_TENANT=default
 # ── Centralized defaults (do not set) ─────────────────────────────────────
 # Applied by config::env unless overridden:
 #   CODER_URL=http://localhost:7080
-#   CODER_IMAGE_TAG=latest
+#   CODER_IMAGE_TAG=v2.37.0
 #   CODER_ADMIN_EMAIL=admin@openflows.dev
 #   CODER_ADMIN_USERNAME=admin
 #   REDIS_URL=redis://localhost:6379

--- a/.env.example
+++ b/.env.example
@@ -10,26 +10,29 @@ GITHUB_TOKEN=ghp_your_token_here
 # Target repository to work on (e.g., my-org/my-repo).
 GITHUB_REPOSITORY=owner/repo
 
+# GitHub REST API base. Only set for a self-hosted GitHub Enterprise or a
+# Gitea-compatible instance; defaults to https://api.github.com.
+# GITHUB_API_BASE=https://api.github.com
+
 # ── Coder (REQUIRED) ──────────────────────────────────────────────────────
 # Personal session token from http://localhost:7080/settings/tokens/new.
 CODER_SESSION_TOKEN=your_token_here
 
 # ── Admin user (optional overrides) ─────────────────────────────────────
-# Defaults apply if unset: admin@openflows.dev / Op3nFl0ws!
+# Email defaults to admin@openflows.dev if unset. There is no baked-in
+# password default — the bootstrapper applies a secure fallback only when
+# none is supplied.
 # CODER_ADMIN_EMAIL=admin@openflows.dev
-# CODER_ADMIN_PASSWORD=Op3nFl0ws!
+# CODER_ADMIN_PASSWORD=your_secure_password_here
 
-# ── Coder GitHub sign-ups ─────────────────────────────────────────────────
-# Sign-ups are enabled by default; set false to disable.
-# CODER_OAUTH2_GITHUB_ALLOW_SIGNUPS=false
-
-# ── Coder GitHub external auth (Git App) ───────────────────────────────────
-# Set these to let agents push/pull against private repos.
+# ── Coder GitHub external auth (OIDC / Git App) ───────────────────────────
+# Set these to allow agents authenticate via OIDC.
 # CODER_EXTERNAL_AUTH_0_ID=primary-github
 # CODER_EXTERNAL_AUTH_0_TYPE=github
 # CODER_EXTERNAL_AUTH_0_CLIENT_ID=your_github_app_client_id
 # CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=your_github_app_client_secret
 # CODER_EXTERNAL_AUTH_0_SCOPES=repo
+# CODER_EXTERNAL_AUTH_0_APP_INSTALL_URL=https://github.com/apps/<your-app-slug>/installations/new
 
 # ── Coder Agent Lifecycle Hooks (EXPERIMENTAL) ─────────────────────────────
 # Enables OpenFlows as the CONSUMER of Coder's experimental
@@ -60,9 +63,10 @@ OPENFLOWS_TENANT=default
 #   CODER_URL=http://localhost:7080
 #   CODER_IMAGE_TAG=latest
 #   CODER_ADMIN_EMAIL=admin@openflows.dev
-#   CODER_ADMIN_PASSWORD=Op3nFl0ws!
+#   CODER_ADMIN_USERNAME=admin
 #   REDIS_URL=redis://localhost:6379
 #   A2A_RELAY_ADDR=127.0.0.1:3000
 #   OPENFLOWS_TENANT=default
 #   OPENFLOWS_TAR=tar
+#   GITHUB_API_BASE=https://api.github.com
 #   USE_AI_GATEWAY=false

--- a/.env.example
+++ b/.env.example
@@ -36,18 +36,23 @@ CODER_SESSION_TOKEN=your_token_here
 
 # ── Coder Agent Lifecycle Hooks (EXPERIMENTAL) ─────────────────────────────
 # Enables OpenFlows as the CONSUMER of Coder's experimental
-# agent-lifecycle-hooks webhook. Set these on the Coder server to emit events:
+# agent-lifecycle-hooks webhook. These three vars are forwarded to the Coder
+# server (see docker-compose.yml) so Coder emits events; the same URL/secret
+# are read by the OpenFlows controller to host the consumer endpoint:
 #   CODER_EXPERIMENTS=agent-lifecycle-hooks
 #   CODER_CHAT_HOOK_URL=http://<openflows-host>:3001/hooks/chat
 #   CODER_CHAT_HOOK_SECRET=<>=32 random bytes>
-# On the OpenFlows controller side (this file):
-#   CODER_CHAT_HOOK_URL=http://<openflows-host>:3001/hooks/chat
-#   CODER_CHAT_HOOK_SECRET=<the same 32+ byte secret>
-# OpenFlows then verifies the HS256 JWT and records every lifecycle event
+# When Coder runs in Docker, <openflows-host> must be reachable from inside
+# the container (NOT localhost). This repo maps host.docker.internal to the
+# host via extra_hosts (host-gateway) in docker-compose.yml, so the URL is:
+#   CODER_CHAT_HOOK_URL=http://host.docker.internal:3001/hooks/chat
+# The consumer must then listen on a container-reachable interface, so set
+# OPENFLOWS_HOOK_ADDR to 0.0.0.0:3001 (not 127.0.0.1) when Coder is in Docker.
+# OpenFlows verifies the HS256 JWT and records every lifecycle event
 # (session_start / user_prompt_submit / pre_tool_use / post_tool_use /
 # pre_compact / post_compact / stop) to a tenant-scoped Redis audit trail at
 # ns:{tenant}:_hook_events_tail.
-# OPENFLOWS_HOOK_ADDR=127.0.0.1:3001
+# OPENFLOWS_HOOK_ADDR=0.0.0.0:3001
 
 # ── Infrastructure ────────────────────────────────────────────────────────
 # Only set if you host Redis or Coder elsewhere than the local stack.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,16 +50,20 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "base64",
  "chrono",
  "coder-client",
  "config",
  "futures",
  "github",
+ "jsonwebtoken",
  "notifier",
  "pocketflow-core",
  "provisioner",
+ "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -480,6 +484,12 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "digest"
@@ -1114,6 +1124,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,6 +1303,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +1420,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,6 +1463,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1909,6 +1975,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,6 +2107,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64",
+ "config",
+ "envconfig",
  "futures",
  "futures-util",
  "reqwest",
@@ -782,6 +784,7 @@ name = "github"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "config",
  "pocketflow-core",
  "rand 0.8.6",
  "regex",
@@ -1447,6 +1450,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "config",
  "fred",
  "futures",
  "serde",

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,222 +1,191 @@
 # OpenFlows — Quick Start
 
-This guide covers everything you need to get OpenFlows running on a fresh machine: prerequisites, one-time setup (`.env`, Docker, bootstrap, licenses, tokens), adding a tenant, running the controller, verifying it works, and common troubleshooting.
+Get OpenFlows running on a fresh machine in 10 steps. For what OpenFlows is and how it works, see the [README](README.md).
 
-> **Overview:** For what OpenFlows is, its architecture, how far it has come, and what's left to finish, see the [README](README.md).
->
-> **Working directory:** Unless stated otherwise, all commands are run from the **project root** (the directory containing `docker-compose.yml`). There is no need to `cd` into subdirectories.
-
----
+> **Working directory:** all commands run from the **project root** (the directory containing `docker-compose.yml`). No need to `cd` into subdirectories.
 
 ## Prerequisites
 
-- **Docker 24+** — runs Redis, the Coder database, and Coder itself.
-- **Rust 1.70+** — builds the `openflows` binary during bootstrap.
-- **Node 18+** — for the GitHub MCP tooling used by agents.
-- **The `coder` CLI** on your `PATH` — `prod.sh bootstrap` shells out to `coder templates push`. Install it if missing:
+- Docker 24+
+- Rust 1.70+ (builds the `openflows` binary during bootstrap)
+- Node 18+
+- The `coder` CLI on your `PATH` — bootstrap shells out to `coder templates push`:
   ```bash
   curl -fsSL https://coder.com/install.sh | sh
   ```
-  Then make sure `coder` is on your `PATH` (re-login or add `~/.local/bin` / `~/bin`) and confirm with `coder version`.
-- **A GitHub personal access token** with the `repo` scope.
+- A GitHub personal access token with the `repo` scope.
 
 ---
 
-## Step 1 — Configure the environment
+## Step 1 — Start Docker
 
-Run this from the **project root** to create your local `.env`:
+First, make sure ports 6379 (Redis) and 7080 (Coder) are free so there's no conflict. If you ran OpenFlows before, cleanly stop this project's containers:
 
 ```bash
-cp .env.example .env
+docker compose down
 ```
 
-Open `.env` and fill in the required variables. The file is well-commented; the table below summarizes every variable so you know what to set and why.
+If another, unrelated container is already holding one of those ports (e.g. a `streamr-redis` on 6379), find it and remove only that one by name:
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `GITHUB_TOKEN` | **Yes** | GitHub PAT with the `repo` scope — used to sync issues and create PRs. Get it at <https://github.com/settings/tokens> (classic token, `repo` scope). |
-| `GITHUB_REPOSITORY` | **Yes** | Your repo as `owner/repo` (e.g. `my-org/my-repo`). The controller watches this repo for new issues. |
-| `CODER_SESSION_TOKEN` | **Yes** | API token for authenticating with Coder. Leave empty in Step 1 — you will paste it in [Step 4](#step-4--sign-in-add-a-coder-license--get-the-api-token). |
+```bash
+docker ps --filter "publish=6379" --filter "publish=7080"
+docker rm -f <conflicting-container-name>
+```
 
-The following variables are optional — the system uses defaults that work out of the box with `docker compose up -d`. Only set them if you host Redis or Coder elsewhere, or want to customize the admin account:
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `REDIS_URL` | `redis://localhost:6379` | Connection URL for Redis. |
-| `CODER_URL` | `http://localhost:7080` | HTTP URL of the Coder server. |
-| `CODER_ADMIN_USERNAME` | `admin` | Admin username created by bootstrap. |
-| `CODER_ADMIN_EMAIL` | `admin@openflows.dev` | Admin email created by bootstrap. |
-| `CODER_ADMIN_PASSWORD` | `Op3nFl0ws!` | Admin password created by bootstrap. Must be ≥8 chars with uppercase, lowercase, digit, and special character — otherwise bootstrap silently falls back to the default. |
-| `OPENFLOWS_TENANT` | `default` | Namespace prefix for Redis keys. |
-
-> **`.dev-binaries` note:** This directory is created and populated automatically during bootstrap and is bind-mounted into Coder workspaces. If bootstrap fails with `cp: ...: Permission denied`, the directory has become `root`-owned. Fix it:
-> ```bash
-> sudo chown -R "$USER":"$USER" .dev-binaries/
-> ```
-> (Create it first if needed: `mkdir -p .dev-binaries`.)
-
----
-
-## Step 2 — Start the Docker infrastructure
-
-Run this from the **project root** to bring up Redis, the Coder database, and the Coder server:
+Then bring up Redis, the Coder database, and the Coder server:
 
 ```bash
 docker compose up -d
 ```
 
-**What this does:** Starts three containerized services (defined in `docker-compose.yml`) that the controller depends on at runtime:
-
-- **Redis** — the shared state store used by the controller to track tickets, worker assignments, and gate approvals (port `6379`).
-- **coder-db** — PostgreSQL database that stores Coder's configuration and users (no external port).
-- **coder** — the Coder server that provisions and manages workspaces for the AI agents (port `7080`).
-
-Wait until all services are healthy:
+Wait until all three report healthy:
 
 ```bash
 docker compose ps
 ```
 
-You should see `redis`, `coder-db`, and `coder` all reporting `healthy` (or `running`). The `coder` service runs a healthcheck, so give it a few seconds on first start.
+---
 
-> **Port 6379 conflict:** If the container fails with `failed to bind host port 0.0.0.0:6379/tcp: address already in use`, another process or container is already bound to port 6379 (e.g. a `streamr-redis` container). Remove or stop the conflicting container, or change the port mapping in `docker-compose.yml`.
+## Step 2 — Set up `.env`
+
+Create your `.env` from the template:
+
+```bash
+cp .env.example .env
+```
+
+Only these three are required:
+
+| Variable | What to put |
+|----------|-------------|
+| `GITHUB_TOKEN` | GitHub PAT with `repo` scope. |
+| `GITHUB_REPOSITORY` | The repo the controller watches, as `owner/repo`. |
+| `CODER_SESSION_TOKEN` | Leave empty for now — you'll fill it in [Step 4](#step-4--get-your-coder-session-token). |
 
 ---
 
-## Step 3 — Bootstrap (one-time setup)
+## Step 3 — Sign in with GitHub
 
-Run this from the **project root** to initialize Coder with the templates and configuration OpenFlows needs:
+Open **http://localhost:7080** and sign in with your GitHub account (Coder's device flow).
+
+---
+
+## Step 4 — Get your Coder session token
+
+1. Open **http://localhost:7080/settings/tokens**
+2. Click **Create Token**, copy it.
+3. Paste it into `.env`:
+   ```bash
+   CODER_SESSION_TOKEN=your_token_here
+   ```
+
+---
+
+## Step 5 — Configure an LLM model
+
+OpenFlows agents need at least one model.
+
+1. Go to **http://localhost:7080/ai/settings/providers**
+2. **Add a provider** (e.g. OpenAI, Anthropic).
+3. Go to **http://localhost:7080/ai/settings/models** and **add a model** to that provider (e.g. `deepseek-v4-flash-0731`).
+
+---
+
+## Step 6 — Test the AI setup
+
+Open **http://localhost:7080/agents** and confirm agents/models show up. Say "hello" in the chat to verify the model responds.
+
+---
+
+## Step 7 — Bootstrap
+
+Run the one-time setup to initialize Coder with the OpenFlows templates and config:
 
 ```bash
 ./scripts/prod.sh bootstrap
 ```
 
-**What this does and why each step matters:**
+This builds the `openflows` binary into `.dev-binaries/`, creates the admin user, pushes the workspace templates, and verifies GitHub/LLM auth.
 
-1. **Build and sync dev binaries** — compiles the `openflows` binary in release mode, then copies it to `.dev-binaries/`. This directory is mounted into Coder workspaces so they have the latest version of the tool.
-2. **Create the admin user in Coder** — creates the initial admin account using the credentials from `.env` (see Step 4 for defaults).
-3. **Push workspace templates** — deploys the `nexus`, `forge`, `sentinel`, `vessel`, and `lore` templates to Coder. These templates define the workspaces that each AI agent will run in.
-4. **Verify LLM/GitHub auth** — checks that a GitHub token is present and that at least one LLM model is configured in Coder's AI settings.
+Confirm the templates were pushed at **http://localhost:7080/templates**.
 
 ---
 
-## Step 4 — Sign in, add a Coder license & get the API token
+## Step 8 — Add a tenant
 
-The bootstrap script creates the initial Coder admin account. By default the credentials are:
-
-| Field | Default |
-|-------|---------|
-| Username | `admin` |
-| Email | `admin@openflows.dev` |
-| Password | `Op3nFl0ws!` |
-
-Override them with `CODER_ADMIN_USERNAME` / `CODER_ADMIN_EMAIL` / `CODER_ADMIN_PASSWORD` in `.env` before running bootstrap.
-
-> **Password requirements:** If the `CODER_ADMIN_PASSWORD` you set does not meet Coder's security requirements (at least 8 characters, and containing an uppercase letter, a lowercase letter, a digit, and a special character), bootstrap **silently falls back to `Op3nFl0ws!`** and creates the admin with that instead. Either set a password that satisfies these requirements, or sign in with the default `Op3nFl0ws!` (check the bootstrap output for the "falling back to default" warning).
-
-Then:
-
-1. Open **http://localhost:7080**
-2. **Sign in with the admin credentials above** (first-time only). GitHub sign-up is enabled by default — team members can sign in with their GitHub accounts via Coder's device flow.
-3. **Add a Coder license** — create a license from your account at coder.com, then add it at **[http://localhost:7080/deployment/licenses/add](http://localhost:7080/deployment/licenses/add)**. Coder requires a valid license before some functionality is enabled. For local development you can use Coder's free/developer license — see <https://coder.com/docs/next/admin/licenses>.
-4. **Configure an LLM model** — OpenFlows agents need at least one model configured. Go to **[http://localhost:7080/ai-settings/agents](http://localhost:7080/ai-settings/agents)** → click the **Models** tab and add a provider/model (e.g. OpenAI, Anthropic).
-5. Click your **username** (top-right corner) → **Account** → **Tokens** (or go directly to **[http://localhost:7080/settings/tokens](http://localhost:7080/settings/tokens)**).
-6. Click **Create Token**, copy the token, and paste it into `.env` as:
-   ```bash
-   CODER_SESSION_TOKEN=your_token_here
-   ```
-
-### Step 4a — Grant a non-admin (OAuth) user the permissions OpenFlows needs
-
-When a team member signs in with GitHub OAuth, Coder creates them as a **regular member**. A regular member can *access* templates but **cannot create workspaces or push templates**. If you want OpenFlows to run as that user (instead of the hardcoded `admin`), you must grant them the right roles — otherwise bootstrap fails with `403 Unauthorized to create workspace`.
-
-**Roles OpenFlows needs:**
-
-| Role | Why |
-|------|-----|
-| `organization-admin` | Grants `workspace:create` (create the `openflows-nexus` control-plane workspace) and template management in the org. |
-| `organization-template-admin` | Grants template management (push/update the `openflows-*` templates). |
-| `organization-workspace-access` | OAuth users get this by default; it grants access to org workspaces and is required to create/build the `openflows-nexus` workspace. Keep it — `edit-roles` replaces the whole role set. |
-
-> **⚠️ Important — the `organization-workspace-creation-ban` trap:** This role carries a *negative* `workspace:create` permission that **overrides** `organization-admin`. A user who is org-admin but also has this role still gets `403 Unauthorized to create workspace`. If you see that error, check that this role is **not** assigned.
-
-**Via CLI:**
-
-> **Note:** `edit-roles` **replaces** the user's entire organization-role set rather than appending to it. In particular, a GitHub OAuth user already has `organization-workspace-access` — dropping it removes their ability to create and use org workspaces, so bootstrap would still fail with `403 Unauthorized to create workspace`. Include ALL existing roles (custom, Coder Agents, and `organization-workspace-access`) on this command, or they'll be removed.
-
-```bash
-export CODER_URL=http://localhost:7080
-export CODER_SESSION_TOKEN=<your-token>
-
-# List your organizations (note the org name, e.g. "coder")
-coder organizations list
-
-# Grant the roles (replace <org> and <username>; include ANY existing roles as well, e.g. organization-workspace-access)
-coder organizations members edit-roles -O=<org> <username> \
-  organization-admin \
-  organization-template-admin \
-  organization-workspace-access
-
-# Verify the user's roles
-coder organizations members list -O=<org>
-```
-
-**Via the dashboard:**
-1. Open **http://localhost:7080**
-2. Go to **Admin settings → Organizations → `<your org>` → Members**
-3. Find the user, click **Edit roles**, and select `organization-admin` and `organization-template-admin`. Keep `organization-workspace-access` selected as well.
-4. Confirm `organization-workspace-creation-ban` is **not** selected.
-
-Then set that user's token in `.env` as `CODER_SESSION_TOKEN` and re-run `./scripts/prod.sh bootstrap` — OpenFlows will run as that user instead of `admin`.
-
----
-
-## Step 5 — Add a tenant
-
-Run this from the **project root** to bind a GitHub repository to the controller:
+Bind a GitHub repo to the controller:
 
 ```bash
 ./scripts/prod.sh tenant <owner/repo> --name <my-team>
 ```
 
-**What this does:** Register a team as a tenant so the controller can sync issues from the given repo, provision workspaces, and coordinate agents for that team. You must add at least one tenant before starting the controller. See [TOKEN_GUIDE.md](TOKEN_GUIDE.md) for the token acquisition walkthrough.
+You'll see the tenant under **http://localhost:7080/workspaces**.
 
 ---
 
-## Step 6 — Run the controller
+## Step 9 — Run the controller
 
-Run this from the **project root** (open a **separate terminal** — the controller runs in the foreground and streams logs to that terminal):
+Open a **separate terminal** (the controller runs in the foreground and streams logs) and run:
 
 ```bash
 ./scripts/prod.sh run
 ```
 
-**What this does and why:** The controller is the brain of OpenFlows. It syncs open GitHub issues as tickets, assigns them to available forge workers, provisions Coder workspaces for those workers, and coordinates the agent team through the full issue-to-PR lifecycle.
-
-This command **always** resets Redis to a clean slate first (removing any stale tickets, workers, and gate records from previous runs), then starts the controller in the foreground.
-
-Create a GitHub issue in a bound repo → OpenFlows automatically assigns, provisions a workspace, and starts working.
+Create a GitHub issue in the bound repo → OpenFlows automatically assigns it, provisions a workspace, and starts working.
 
 ---
 
-## Step 7 — Verify it's working
+## Verify it's working
 
-Because the controller runs in the foreground, its logs stream directly to the terminal where you started `./scripts/prod.sh run`. In a **separate terminal** (also from the project root) you can verify:
+In a separate terminal:
 
 ```bash
-# Health check
 ./scripts/prod.sh doctor
 ```
 
-Confirm the Docker services are healthy:
+---
+
+## Configuration
+
+These are optional — the defaults work out of the box. Only touch them if you need to.
+
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `CODER_ADMIN_USERNAME` | `admin` | Admin account created by bootstrap. |
+| `CODER_ADMIN_EMAIL` | `admin@openflows.dev` | |
+| `CODER_ADMIN_PASSWORD` | `Op3nFl0ws!` | Must be ≥8 chars with upper, lower, digit, and special char — otherwise bootstrap silently falls back to the default. |
+| `REDIS_URL` | `redis://localhost:6379` | Set only if you host Redis elsewhere. |
+| `CODER_URL` | `http://localhost:7080` | Set only if you host Coder elsewhere. |
+| `OPENFLOWS_TENANT` | `default` | Namespace for Redis keys. |
+| `SLACK_WEBHOOK_URL` / `DISCORD_WEBHOOK_URL` | unset | Escalation notifications. |
+
+### Granting a non-admin (OAuth) user the needed permissions
+
+When a team member signs in with GitHub OAuth, Coder creates them as a **regular member**, who can't create workspaces or push templates. If you want OpenFlows to run as that user, grant them these roles (or bootstrap fails with `403 Unauthorized to create workspace`):
+
+| Role | Why |
+|------|-----|
+| `organization-admin` | Create the control-plane workspace + template management. |
+| `organization-template-admin` | Push/update the `openflows-*` templates. |
+| `organization-workspace-access` | Required for org workspaces. Keep it — `edit-roles` replaces the whole role set. |
+
+> **Trap:** `organization-workspace-creation-ban` carries a *negative* `workspace:create` permission that **overrides** `organization-admin`. If you see `403 Unauthorized to create workspace`, make sure this role is **not** assigned.
+
+Via CLI:
 
 ```bash
-docker compose ps
+export CODER_URL=http://localhost:7080
+export CODER_SESSION_TOKEN=<your-token>
+
+# List orgs, then grant roles (include ALL existing roles or they'll be removed)
+coder organizations list
+coder organizations members edit-roles -O=<org> <username> \
+  organization-admin \
+  organization-template-admin \
+  organization-workspace-access
 ```
 
-A successful health check shows Coder and Redis healthy. Verify the controller separately by confirming that its foreground terminal remains running and streams sync/provisioning activity after you create an issue.
-
-> **On `/tmp/openflows-controller.log`:** That log file only exists in the **production** flow, where the controller runs inside a Nexus workspace and its startup script redirects output (`openflows run >/tmp/openflows-controller.log`). Locally, `prod.sh run` runs in the foreground — watch that terminal instead.
+Or via the dashboard: **Admin settings → Organizations → `<your org>` → Members → Edit roles** and select the roles above.
 
 ---
 
@@ -224,72 +193,39 @@ A successful health check shows Coder and Redis healthy. Verify the controller s
 
 ### `Failed to run coder templates push` (during bootstrap)
 
-The `coder` CLI is missing or not on your `PATH`. Bootstrap shells out to `coder templates push`. Install it:
+`coder` is missing or not on your `PATH`. Install it and re-run bootstrap:
 
 ```bash
 curl -fsSL https://coder.com/install.sh | sh
-```
-
-Ensure `coder` is on your `PATH`, confirm with `coder version`, then re-run bootstrap.
-
-### `CODER_URL not set` / `Error: Failed to create bootstrapper from environment` (during bootstrap)
-
-The CLI defaults to `http://localhost:7080` when `CODER_URL` is not set, so the old bootstrap error should no longer appear. If you still see a connection failure, check that `CODER_URL` in `.env` is not set to an empty or malformed value — an empty value (`CODER_URL=`) is treated as the URL itself rather than falling back to the default. If you do need a different URL, set it to a valid value:
-
-```bash
-CODER_URL=http://your-coder-host:7080
-```
-
-### `REDIS_URL is not set` (during `prod.sh run`)
-
-The CLI defaults to `redis://localhost:6379` when `REDIS_URL` is not set, so the old run error should no longer appear. If you still see a connection failure, check that `REDIS_URL` in `.env` is not set to an empty or malformed value — an empty value (`REDIS_URL=`) is treated as the URL itself rather than falling back to the default. If you do need a different URL, set it to a valid value:
-
-```bash
-REDIS_URL=redis://your-redis-host:6379
+coder version
 ```
 
 ### "No LLM models configured in Coder"
 
-Open the Coder dashboard → **[http://localhost:7080/ai-settings/agents](http://localhost:7080/ai-settings/agents)** → click the **Models** tab and configure at least one provider/model, then re-run bootstrap.
+Open **http://localhost:7080/ai/settings/providers** and add a provider/model, then re-run bootstrap.
 
 ### `cp: cannot create regular file '.dev-binaries/openflows': Permission denied`
 
-The `.dev-binaries/` directory is `root`-owned. Take ownership:
+The `.dev-binaries/` directory is root-owned:
 
 ```bash
 sudo chown -R "$USER":"$USER" .dev-binaries/
 ```
 
-### Missing required environment variables
+### Port 6379 already in use
 
-Make sure `.env` is in the project root:
-
-```bash
-cp .env.example .env
-# Edit .env with your tokens
-```
-
-### Redis container not responding
-
-```bash
-docker ps | grep redis
-docker compose up -d   # restart if needed
-```
-
-### `failed to bind host port 0.0.0.0:6379/tcp: address already in use`
-
-Another process or container already holds port 6379. Find the conflicting container with `docker ps --format '{{.Names}}\t{{.Ports}}' | grep 6379` and remove/stop it (e.g. `docker rm -f streamr-redis`), or change the redis port mapping in `docker-compose.yml`.
+Another process/container holds port 6379. Stop or remove the conflicting container, or change the Redis port mapping in `docker-compose.yml`.
 
 ### Controller not picking up issues
 
 1. Confirm a tenant is bound (`./scripts/prod.sh tenant <owner/repo> --name <my-team>`).
-2. Check the terminal running the controller for errors (locally) — or `tail -f /tmp/openflows-controller.log` in the production flow.
+2. Watch the controller's foreground terminal for errors.
 3. Verify Coder is reachable: `curl http://localhost:7080/api/v2/buildinfo`.
 
 ---
 
-## For More Details
+## More
 
-- **Full Documentation**: See [README.md](README.md)
-- **Testing & Debugging**: See [TESTING_QUICK_START.md](TESTING_QUICK_START.md)
-- **Token Acquisition**: See [TOKEN_GUIDE.md](TOKEN_GUIDE.md)
+- **Full docs:** [README.md](README.md)
+- **Testing & debugging:** [TESTING_QUICK_START.md](TESTING_QUICK_START.md)
+- **Token acquisition:** [TOKEN_GUIDE.md](TOKEN_GUIDE.md)

--- a/binary/src/bin/agentflow.rs
+++ b/binary/src/bin/agentflow.rs
@@ -140,10 +140,14 @@ enum HooksCommands {
         /// Chat ID to tag the event with (defaults to a generated id)
         #[arg(long)]
         chat_id: Option<String>,
-        /// Optional dispatch ID (defaults to a generated one)
-        #[arg(long)]
-        dispatch_id: Option<String>,
+    /// Optional dispatch ID (defaults to a generated one)
+    #[arg(long)]
+    dispatch_id: Option<String>,
     },
+    /// Run the hook consumer standalone (dev/test). Uses an in-memory store so
+    /// it needs no Redis or Coder. Require CODER_EXPERIMENTS=agent-lifecycle-hooks,
+    /// CODER_CHAT_HOOK_URL and CODER_CHAT_HOOK_SECRET at startup.
+    Serve,
 }
 
 #[tokio::main]
@@ -778,6 +782,38 @@ async fn run_hooks(action: HooksCommands) -> Result<()> {
                 println!("✓ Event observed by the OpenFlows hook consumer.");
             } else {
                 println!("✗ Hook consumer rejected the event. Check the consumer logs.");
+            }
+        }
+        HooksCommands::Serve => {
+            // Standalone consumer for local testing: in-memory store (no Redis),
+            // so `openflows hooks simulate` can fire events at it end-to-end.
+            let cfg = config::EnvConfig::from_env().context(
+                "failed to load environment configuration (CODER_CHAT_HOOK_URL and \
+                 CODER_CHAT_HOOK_SECRET must be exported alongside \
+                 CODER_EXPERIMENTS=agent-lifecycle-hooks)",
+            )?;
+            let store =
+                std::sync::Arc::new(pocketflow_core::SharedStore::new_in_memory());
+            tracing::info!(
+                hook_url = %hook_url,
+                "Starting standalone lifecycle hook consumer (in-memory store)"
+            );
+            match agent_nexus::hooks::start_lifecycle_hook_server(store, cfg.hooks.clone()).await
+            {
+                Ok(Some(())) => {
+                    println!("Listening on {}", cfg.hooks.hook_addr);
+                    println!("Configure `openflows hooks simulate` with the same CODER_CHAT_HOOK_URL and CODER_CHAT_HOOK_SECRET.");
+                    // Keep the process alive serving requests.
+                    loop {
+                        tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+                    }
+                }
+                Ok(None) => {
+                    anyhow::bail!(
+                        "consumer not started: set CODER_EXPERIMENTS=agent-lifecycle-hooks and CODER_CHAT_HOOK_URL"
+                    );
+                }
+                Err(e) => anyhow::bail!("failed to start consumer: {e:#}"),
             }
         }
     }

--- a/binary/src/bin/agentflow.rs
+++ b/binary/src/bin/agentflow.rs
@@ -51,6 +51,11 @@ enum Commands {
         #[command(subcommand)]
         action: GateCommands,
     },
+    /// Coder agent lifecycle hooks (experimental) — simulate/test the consumer
+    Hooks {
+        #[command(subcommand)]
+        action: HooksCommands,
+    },
     /// Reset orchestration files to bundled defaults
     ResetOrchestration,
 }
@@ -119,6 +124,28 @@ enum GateCommands {
     },
 }
 
+#[derive(Subcommand)]
+enum HooksCommands {
+    /// Simulate Coder dispatching a lifecycle hook event to the consumer.
+    ///
+    /// Signs a JWT exactly like Coder's `chatd` (HS256, iss=coder,
+    /// aud=CODER_CHAT_HOOK_URL, jti=dispatch_id, body_sha256) and POSTs it to
+    /// the configured URL. Lets you exercise the consumer end-to-end without a
+    /// Coder server.
+    Simulate {
+        /// Event to dispatch (session_start, user_prompt_submit, pre_tool_use,
+        /// post_tool_use, pre_compact, post_compact, stop)
+        #[arg(long, default_value = "session_start")]
+        event: String,
+        /// Chat ID to tag the event with (defaults to a generated id)
+        #[arg(long)]
+        chat_id: Option<String>,
+        /// Optional dispatch ID (defaults to a generated one)
+        #[arg(long)]
+        dispatch_id: Option<String>,
+    },
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Load .env if present (dev / host CLI use). In the nexus workspace, vars
@@ -140,6 +167,7 @@ async fn main() -> Result<()> {
         Commands::Status { tenant, json } => run_status(tenant, json).await,
         Commands::Doctor => openflows::doctor::run_checks().await,
         Commands::Gate { action } => run_gate(action).await,
+        Commands::Hooks { action } => run_hooks(action).await,
         Commands::ResetOrchestration => run_reset().await,
     }
 }
@@ -186,6 +214,28 @@ async fn run_controller() -> Result<()> {
             None
         }
     };
+
+    // ── Coder Agent Lifecycle Hooks (experimental) ──────────────────────
+    // OpenFlows consumes Coder's deployment-wide `agent-lifecycle-hooks`
+    // webhook so we can observe (and later centrally policy) every agent
+    // lifecycle event. Gated by CODER_EXPERIMENTS=agent-lifecycle-hooks +
+    // CODER_CHAT_HOOK_URL; no-op otherwise.
+    match agent_nexus::hooks::start_lifecycle_hook_server(
+        std::sync::Arc::new(store.clone()),
+        cfg.hooks.clone(),
+    )
+    .await
+    {
+        Ok(Some(())) => tracing::info!("Coder lifecycle hook consumer started"),
+        Ok(None) => tracing::debug!("Coder lifecycle hook consumer disabled"),
+        Err(e) => {
+            // Experimental: warn but do not fail the controller boot.
+            tracing::warn!(
+                error = %e,
+                "Failed to start Coder lifecycle hook consumer; continuing without hooks"
+            );
+        }
+    }
 
     // ── Resolve orchestration directory ─────────────────────────────────
     let resolver = openflows::orchestration::OrchestrationResolver::new()?;
@@ -674,6 +724,61 @@ async fn run_gate(action: GateCommands) -> Result<()> {
         } => {
             let store = Harness::new(&redis_url, &tenant).await?;
             store.gate_status(&ticket, &phase).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn run_hooks(action: HooksCommands) -> Result<()> {
+    // The consumer reads these from the environment at startup, matching Coder.
+    let hook_url = std::env::var("CODER_CHAT_HOOK_URL").context(
+        "CODER_CHAT_HOOK_URL is not set. Point it at the OpenFlows hook consumer \
+         (e.g. http://127.0.0.1:3001/hooks/chat).",
+    )?;
+    let secret = std::env::var("CODER_CHAT_HOOK_SECRET").context(
+        "CODER_CHAT_HOOK_SECRET is not set. It must match the consumer's.\n\
+         Generate one with: openssl rand -hex 32",
+    )?;
+
+    match action {
+        HooksCommands::Simulate {
+            event,
+            chat_id,
+            dispatch_id,
+        } => {
+            // Generate stable-ish test ids from the process id + timestamp (no
+            // extra dependency needed in the binary crate).
+            let ts = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis())
+                .unwrap_or(0);
+            let pid = std::process::id();
+            let dispatch_id = dispatch_id
+                .unwrap_or_else(|| format!("sim-{}-{}", event.replace('_', "-"), pid));
+            let chat_id = chat_id.unwrap_or_else(|| format!("chat-sim-{}-{}", pid, ts));
+
+            println!(
+                "Simulating Coder dispatch → `{}` (event={event}, dispatch_id={dispatch_id})",
+                hook_url
+            );
+            let (status, body) = agent_nexus::hooks::dispatch_simulated_event(
+                &hook_url,
+                &secret,
+                &event,
+                &chat_id,
+                &dispatch_id,
+            )
+            .await?;
+            println!("Consumer responded with HTTP {status}");
+            if !body.trim().is_empty() {
+                println!("Response body: {body}");
+            }
+            if status == 200 || status == 204 {
+                println!("✓ Event observed by the OpenFlows hook consumer.");
+            } else {
+                println!("✗ Hook consumer rejected the event. Check the consumer logs.");
+            }
         }
     }
 

--- a/binary/src/bin/agentflow.rs
+++ b/binary/src/bin/agentflow.rs
@@ -181,8 +181,8 @@ async fn run_controller() -> Result<()> {
     cfg.validate_controller()?;
     let coder_url = cfg.coder.url.clone();
     let _coder_token = cfg.coder.effective_token();
-    let redis_url = cfg.infra.redis_url.clone();
-    let tenant = cfg.tenant.tenant.clone();
+    let redis_url = cfg.infra.effective_redis_url();
+    let tenant = cfg.tenant.effective_tenant().to_string();
     let github_repo = cfg
         .github
         .repository
@@ -419,7 +419,7 @@ async fn run_bootstrap() -> Result<()> {
         eprintln!("\n  ⚠ {}", e);
     }
 
-    println!("\nBootstrap complete. Run `openflows tenant add <owner/repo>` to add a tenant.");
+    println!("\nBootstrap complete.");
     Ok(())
 }
 
@@ -428,8 +428,7 @@ async fn run_tenant_clean(action: &TenantCommands) -> Result<()> {
         unreachable!("run_tenant_clean called with non-clean action");
     };
 
-    let redis_url =
-        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+    let redis_url = config::EnvConfig::from_env()?.infra.effective_redis_url();
     // Scope the store to the tenant we are cleaning: SharedStore namespaces
     // every key as `ns:{tenant}:{key}`, so we pass it the tenant and use plain
     // keys below. (We must NOT also hand-format `ns:{name}:` prefixes here,
@@ -544,8 +543,7 @@ async fn run_tenant(action: TenantCommands) -> Result<()> {
         TenantCommands::List => {
             println!("Tenants (from Redis namespaces):");
             // Read all ns:* keys from Redis and list unique tenants
-            let redis_url =
-                std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+            let redis_url = config::EnvConfig::from_env()?.infra.effective_redis_url();
             match pocketflow_core::SharedStore::new_redis(&redis_url).await {
                 Ok(store) => {
                     // raw_keys scans full Redis keys (`ns:*`) without re-applying
@@ -576,8 +574,7 @@ async fn run_tenant(action: TenantCommands) -> Result<()> {
             println!("Removing tenant '{}'...", name);
 
             if purge {
-                let redis_url = std::env::var("REDIS_URL")
-                    .unwrap_or_else(|_| "redis://localhost:6379".to_string());
+                let redis_url = config::EnvConfig::from_env()?.infra.effective_redis_url();
                 match pocketflow_core::SharedStore::new_redis(&redis_url).await {
                     Ok(store) => {
                         // raw_keys + raw_del operate on full keys, so we purge the
@@ -609,8 +606,7 @@ async fn run_tenant(action: TenantCommands) -> Result<()> {
 }
 
 async fn run_status(tenant: Option<String>, json: bool) -> Result<()> {
-    let redis_url =
-        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+    let redis_url = config::EnvConfig::from_env()?.infra.effective_redis_url();
 
     // raw_keys scans full Redis keys without namespacing, so we can enumerate
     // all `ns:{tenant}:` namespaces from a single store.
@@ -696,8 +692,7 @@ async fn run_status(tenant: Option<String>, json: bool) -> Result<()> {
 async fn run_gate(action: GateCommands) -> Result<()> {
     use openflows_harness::Harness;
 
-    let redis_url =
-        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+    let redis_url = config::EnvConfig::from_env()?.infra.effective_redis_url();
 
     match action {
         GateCommands::Approve {

--- a/binary/src/debug.rs
+++ b/binary/src/debug.rs
@@ -1,5 +1,6 @@
 use crate::state::{Ticket, WorkerSlot, KEY_TICKETS, KEY_WORKER_SLOTS};
 use anyhow::Result;
+use config::Envconfig;
 use pocketflow_core::SharedStore;
 use std::collections::HashMap;
 
@@ -7,7 +8,7 @@ pub async fn debug_system() -> Result<()> {
     println!("=== AgentFlow Debug Info ===");
 
     // Check Redis / Store
-    let store = if let Ok(url) = std::env::var("REDIS_URL") {
+    let store = if let Some(url) = config::InfraConfig::init_from_env()?.redis_url {
         println!("Store: Redis ({})", url);
         SharedStore::new_redis(&url).await?
     } else {

--- a/binary/src/doctor.rs
+++ b/binary/src/doctor.rs
@@ -15,6 +15,13 @@ pub async fn run_checks() -> Result<()> {
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
         .build()?;
+    let pinned = config::CoderConfig::init_from_env()?.image_tag;
+    let semver = is_semver_tag(&pinned);
+    let pinned = match &pinned[..] {
+        _ if !semver => pinned,
+        t if t.starts_with('v') => t.to_string(),
+        t => format!("v{t}"),
+    };
     match client
         .get(format!(
             "{}/api/v2/buildinfo",
@@ -24,7 +31,31 @@ pub async fn run_checks() -> Result<()> {
         .await
     {
         Ok(resp) if resp.status().is_success() => {
+            let body: serde_json::Value = resp.json().await.unwrap_or_default();
+            let version = body
+                .get("version")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default();
             println!("  ✓ Coder server reachable at {}", coder_url);
+            if semver && !version.is_empty() && version != pinned {
+                println!(
+                    "  ⚠ Coder reports {} but the pinned tag is {} — models/chat may drift",
+                    version, pinned
+                );
+                println!(
+                    "    Fix: Set CODER_IMAGE_TAG={} in docker-compose (or match the running image)",
+                    pinned
+                );
+            } else if !semver {
+                println!(
+                    "  ℹ Running Coder {}",
+                    if version.is_empty() {
+                        "(unknown)"
+                    } else {
+                        version
+                    }
+                );
+            }
         }
         Ok(resp) => {
             println!(
@@ -56,38 +87,51 @@ pub async fn run_checks() -> Result<()> {
             let client = reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(10))
                 .build()?;
-            let resp = client
-                .get(format!(
-                    "{}/api/experimental/chats/models",
-                    coder_url.trim_end_matches('/')
-                ))
-                .header("Coder-Session-Token", &token)
-                .send()
-                .await;
-            match resp {
-                Ok(r) if r.status().is_success() => {
-                    let body = r.text().await.unwrap_or_default();
-                    if body.contains("\"id\"") {
-                        println!("  ✓ LLM models configured in Coder");
-                    } else {
+            let base = coder_url.trim_end_matches('/');
+
+            // Models are organization-scoped in Coder v2.37+: resolve the
+            // default organization first, then query the org-scoped endpoint.
+            let org_id = resolve_default_org_id(&client, base, &token).await;
+
+            if let Some(org_id) = org_id {
+                let resp = client
+                    .get(format!(
+                        "{}/api/v2/organizations/{}/chats/models",
+                        base, org_id
+                    ))
+                    .header("Coder-Session-Token", &token)
+                    .send()
+                    .await;
+                match resp {
+                    Ok(r) if r.status().is_success() => {
+                        let body = r.text().await.unwrap_or_default();
+                        if body.contains("\"id\"") {
+                            println!("  ✓ LLM models configured in Coder");
+                        } else {
+                            println!(
+                                "  ⚠ Could not verify LLM models — check Coder dashboard → AI Settings"
+                            );
+                        }
+                    }
+                    Ok(r) => {
                         println!(
-                            "  ⚠ Could not verify LLM models — check Coder dashboard → AI Settings"
+                            "  ⚠ Chats API returned {} — ensure AI Agents are enabled",
+                            r.status()
+                        );
+                        println!(
+                            "    Fix: Go to Coder dashboard → AI Settings → Coder Agents → Models"
                         );
                     }
+                    Err(_) => {
+                        println!("  ⚠ Could not reach Chats API — Coder may not support it yet");
+                        println!("    Fix: Update Coder to a version with Coder Agents support");
+                    }
                 }
-                Ok(r) => {
-                    println!(
-                        "  ⚠ Chats API returned {} — ensure AI Agents are enabled",
-                        r.status()
-                    );
-                    println!(
-                        "    Fix: Go to Coder dashboard → AI Settings → Coder Agents → Models"
-                    );
-                }
-                Err(_) => {
-                    println!("  ⚠ Could not reach Chats API — Coder may not support it yet");
-                    println!("    Fix: Update Coder to a version with Coder Agents support");
-                }
+            } else {
+                println!(
+                    "  ⚠ Could not resolve Coder default organization — cannot verify LLM models"
+                );
+                println!("    Fix: Go to Coder dashboard → AI Settings → Coder Agents → Models");
             }
         } else {
             println!("  ⚠ No Coder token set — cannot verify LLM config");
@@ -128,4 +172,45 @@ pub async fn run_checks() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Fetch `GET /api/v2/organizations` and resolve the default organization id,
+/// preferring the one flagged `is_default`, else falling back to the first.
+async fn resolve_default_org_id(
+    client: &reqwest::Client,
+    base: &str,
+    token: &str,
+) -> Option<String> {
+    let resp = client
+        .get(format!("{}/api/v2/organizations", base))
+        .header("Coder-Session-Token", token)
+        .send()
+        .await
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let body: serde_json::Value = resp.json().await.ok()?;
+    let orgs = body.as_array()?;
+    let pick = orgs
+        .iter()
+        .find(|o| o.get("is_default").and_then(serde_json::Value::as_bool) == Some(true))
+        .or_else(|| orgs.first())?;
+    pick.get("id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+        .filter(|s| !s.is_empty())
+}
+
+/// Return true when `tag` looks like a semantic version (e.g. `v2.37.0` or
+/// `2.37.0`). Floating tags such as `latest` or branch names return false so
+/// they are never coerced into an invalid `vlatest` and never compared exactly.
+fn is_semver_tag(tag: &str) -> bool {
+    let t = tag.strip_prefix('v').unwrap_or(tag);
+    let bytes = t.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    i > 0 && i < bytes.len() && bytes[i] == b'.'
 }

--- a/binary/src/doctor.rs
+++ b/binary/src/doctor.rs
@@ -2,6 +2,7 @@
 //! Diagnostic checks shared by `openflows doctor` and `openflows-doctor`.
 
 use anyhow::Result;
+use config::Envconfig;
 
 pub async fn run_checks() -> Result<()> {
     let mut all_pass = true;
@@ -10,51 +11,46 @@ pub async fn run_checks() -> Result<()> {
     println!();
 
     // 1. Coder server reachable
-    let coder_url = std::env::var("CODER_URL");
-    match &coder_url {
-        Ok(url) => {
-            let client = reqwest::Client::builder()
-                .timeout(std::time::Duration::from_secs(5))
-                .build()?;
-            match client
-                .get(format!("{}/api/v2/buildinfo", url.trim_end_matches('/')))
-                .send()
-                .await
-            {
-                Ok(resp) if resp.status().is_success() => {
-                    println!("  ✓ Coder server reachable at {}", url);
-                }
-                Ok(resp) => {
-                    println!(
-                        "  ✗ Coder server returned HTTP {} at {}",
-                        resp.status(),
-                        url
-                    );
-                    println!("    Fix: Ensure Coder is running (docker compose up -d)");
-                    all_pass = false;
-                }
-                Err(e) => {
-                    println!("  ✗ Coder server not reachable at {}: {}", url, e);
-                    println!("    Fix: Start Coder (docker compose up -d) and set CODER_URL");
-                    all_pass = false;
-                }
-            }
+    let coder_url = config::CoderConfig::init_from_env()?.url;
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()?;
+    match client
+        .get(format!(
+            "{}/api/v2/buildinfo",
+            coder_url.trim_end_matches('/')
+        ))
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => {
+            println!("  ✓ Coder server reachable at {}", coder_url);
         }
-        Err(_) => {
-            println!("  ✗ CODER_URL is not set");
-            println!("    Fix: Set CODER_URL in .env (e.g., http://localhost:7080)");
+        Ok(resp) => {
+            println!(
+                "  ✗ Coder server returned HTTP {} at {}",
+                resp.status(),
+                coder_url
+            );
+            println!("    Fix: Ensure Coder is running (docker compose up -d)");
+            all_pass = false;
+        }
+        Err(e) => {
+            println!("  ✗ Coder server not reachable at {}: {}", coder_url, e);
+            println!("    Fix: Start Coder (docker compose up -d) and set CODER_URL");
             all_pass = false;
         }
     }
 
     // 2. Coder image tag
-    let tag = std::env::var("CODER_IMAGE_TAG").unwrap_or_else(|_| "latest".to_string());
+    let tag = config::CoderConfig::init_from_env()?.image_tag;
     println!("  ℹ Coder image tag: {} (pin for production)", tag);
 
     // 3. LLM provider/model configured
-    if let Ok(url) = &coder_url {
-        let token = std::env::var("CODER_SESSION_TOKEN")
-            .or_else(|_| std::env::var("CODER_API_TOKEN"))
+    {
+        let token = config::CoderConfig::init_from_env()?
+            .session_token
+            .or(std::env::var("CODER_API_TOKEN").ok())
             .unwrap_or_default();
         if !token.is_empty() {
             let client = reqwest::Client::builder()
@@ -63,7 +59,7 @@ pub async fn run_checks() -> Result<()> {
             let resp = client
                 .get(format!(
                     "{}/api/experimental/chats/models",
-                    url.trim_end_matches('/')
+                    coder_url.trim_end_matches('/')
                 ))
                 .header("Coder-Session-Token", &token)
                 .send()
@@ -99,31 +95,26 @@ pub async fn run_checks() -> Result<()> {
         }
     }
 
-    // 4. GitHub external auth configured
+    // 4. GitHub external auth configured (needed for agent authentication)
     let has_github_auth = std::env::var("CODER_EXTERNAL_AUTH_0_ID").is_ok()
         && std::env::var("CODER_EXTERNAL_AUTH_0_SECRET").is_ok();
     if has_github_auth {
         println!("  ✓ GitHub external auth configured (CODER_EXTERNAL_AUTH_0_ID/SECRET)");
     } else {
-        println!("  ✗ GitHub external auth not configured");
-        println!("    Fix: Create a GitHub OAuth App and set CODER_EXTERNAL_AUTH_0_ID");
-        println!("         and CODER_EXTERNAL_AUTH_0_SECRET in .env, then restart Coder");
-        all_pass = false;
+        println!(
+            "  ⚠ GitHub external auth not configured — optional, only needed for private repos"
+        );
+        println!("    If agents must push to private repos, create a GitHub App and set");
+        println!("         CODER_EXTERNAL_AUTH_0_ID and CODER_EXTERNAL_AUTH_0_SECRET in .env");
     }
 
     // 5. Redis reachable
-    match std::env::var("REDIS_URL") {
-        Ok(url) => match pocketflow_core::SharedStore::new_redis(&url).await {
-            Ok(_) => println!("  ✓ Redis SharedStore reachable at {}", url),
-            Err(e) => {
-                println!("  ✗ Redis not reachable at {}: {}", url, e);
-                println!("    Fix: Start Redis (docker compose up -d redis)");
-                all_pass = false;
-            }
-        },
-        Err(_) => {
-            println!("  ✗ REDIS_URL is not set");
-            println!("    Fix: Set REDIS_URL in .env (e.g., redis://localhost:6379)");
+    let redis_url = config::InfraConfig::init_from_env()?.effective_redis_url();
+    match pocketflow_core::SharedStore::new_redis(&redis_url).await {
+        Ok(_) => println!("  ✓ Redis SharedStore reachable at {}", redis_url),
+        Err(e) => {
+            println!("  ✗ Redis not reachable at {}: {}", redis_url, e);
+            println!("    Fix: Start Redis (docker compose up -d redis)");
             all_pass = false;
         }
     }

--- a/binary/src/orchestration.rs
+++ b/binary/src/orchestration.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use config::Envconfig;
 use tracing::{info, warn};
 
 use crate::bundled::bundled_files;
@@ -17,11 +18,8 @@ pub struct OrchestrationResolver {
 
 impl OrchestrationResolver {
     pub fn new() -> Result<Self> {
-        let openflows_home = std::env::var("OPENFLOWS_HOME")
-            .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
-            .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
-            .ok();
-        let openflows_home_path = openflows_home.map(std::path::PathBuf::from);
+        let tenant = config::TenantConfig::init_from_env()?;
+        let openflows_home_path = Some(tenant.openflows_home());
 
         let mut candidates: Vec<std::path::PathBuf> = Vec::new();
 
@@ -66,15 +64,7 @@ impl OrchestrationResolver {
                 }
             })
             .unwrap_or_else(|| {
-                let home = openflows_home_path.unwrap_or_else(|| {
-                    let home = std::env::var("OPENFLOWS_HOME")
-                        .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
-                        .or_else(|_| {
-                            std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h))
-                        })
-                        .unwrap_or_else(|_| ".openflows".to_string());
-                    std::path::PathBuf::from(home)
-                });
+                let home = tenant.openflows_home();
                 (home, false)
             });
 

--- a/crates/agent-forge/src/lib.rs
+++ b/crates/agent-forge/src/lib.rs
@@ -12,7 +12,7 @@ use config::{
         full_ticket_key, full_ticket_key_flat, KEY_PENDING_PRS, KEY_TICKETS, KEY_TICKET_CHAT,
         KEY_TICKET_CHAT_ACTION, KEY_TICKET_STATUS, KEY_WORKER_SLOTS,
     },
-    Ticket, TicketStatus, WorkerSlot, ACTION_FAILED, ACTION_PR_OPENED,
+    Envconfig, Ticket, TicketStatus, WorkerSlot, ACTION_FAILED, ACTION_PR_OPENED,
 };
 use pocketflow_core::{node::PAUSE_SIGNAL, Action, BatchNode, SharedStore};
 use serde::{Deserialize, Serialize};
@@ -73,12 +73,13 @@ impl ForgePairNode {
     }
 
     async fn coder_client_from_store(store: &SharedStore) -> Option<CoderClient> {
+        let coder = config::CoderConfig::init_from_env().ok();
         let coder_url: Option<String> = store
             .get_typed("coder_url")
             .await
-            .or_else(|| std::env::var("CODER_URL").ok());
-        let coder_token: Option<String> = std::env::var("CODER_SESSION_TOKEN")
-            .ok()
+            .or_else(|| coder.as_ref().map(|c| c.url.clone()));
+        let coder_token: Option<String> = coder
+            .and_then(|c| c.session_token)
             .or_else(|| std::env::var("CODER_API_TOKEN").ok());
         let coder_token = if coder_token.as_deref().is_some_and(|t| !t.is_empty()) {
             coder_token

--- a/crates/agent-lore/src/types.rs
+++ b/crates/agent-lore/src/types.rs
@@ -49,14 +49,12 @@ impl LoreConfig {
     }
 
     /// Create config using per-agent token from registry (if configured).
-    /// Falls back to GITHUB_PERSONAL_ACCESS_TOKEN for backward compatibility.
+    /// Falls back to GITHUB_TOKEN.
     pub fn from_registry(registry_path: impl AsRef<Path>) -> Result<Self> {
         let registry = Registry::load(registry_path)?;
         let github_token = registry.resolve_github_token("lore")?;
 
-        let workspace_root = std::env::var("AGENTFLOW_WORKSPACE_ROOT")
-            .map(std::path::PathBuf::from)
-            .unwrap_or_else(|_| std::env::current_dir().unwrap_or_default());
+        let workspace_root = env_workspace_root();
         let persona_path = workspace_root
             .join("orchestration")
             .join("agent")
@@ -72,9 +70,8 @@ impl LoreConfig {
     }
 
     pub fn from_env() -> Self {
-        let workspace_root = std::env::var("AGENTFLOW_WORKSPACE_ROOT")
-            .map(std::path::PathBuf::from)
-            .unwrap_or_else(|_| std::env::current_dir().unwrap_or_default());
+        let env = config::EnvConfig::from_env().ok();
+        let workspace_root = env_workspace_root();
         let persona_path = workspace_root
             .join("orchestration")
             .join("agent")
@@ -102,15 +99,17 @@ impl LoreConfig {
                     }
                     Err(e) => {
                         tracing::warn!(error = %e, registry = %path.display(), "LORE failed to resolve token from registry, falling back");
-                        std::env::var("GITHUB_PERSONAL_ACCESS_TOKEN").unwrap_or_default()
+                        env.as_ref()
+                            .and_then(|e| e.github.token.clone())
+                            .unwrap_or_default()
                     }
                 }
             }
             _ => {
-                tracing::warn!(
-                    "LORE: registry.json not found, falling back to GITHUB_PERSONAL_ACCESS_TOKEN"
-                );
-                std::env::var("GITHUB_PERSONAL_ACCESS_TOKEN").unwrap_or_default()
+                tracing::warn!("LORE: registry.json not found, falling back to GITHUB_TOKEN");
+                env.as_ref()
+                    .and_then(|e| e.github.token.clone())
+                    .unwrap_or_default()
             }
         };
 
@@ -122,6 +121,17 @@ impl LoreConfig {
             github_token,
         }
     }
+}
+
+/// Resolve the effective workspace root from the centralized config, falling
+/// back to the current directory. Shared by the config constructors so the
+/// resolution logic is defined once.
+fn env_workspace_root() -> std::path::PathBuf {
+    config::EnvConfig::from_env()
+        .ok()
+        .and_then(|e| e.agent.effective_workspace_root())
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_default())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/agent-nexus/Cargo.toml
+++ b/crates/agent-nexus/Cargo.toml
@@ -27,3 +27,9 @@ uuid = { version = "1.0", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 tokio-stream = { workspace = true, features = ["sync"] }
 futures = { workspace = true }
+
+# Coder agent lifecycle hooks (experimental) consumer
+jsonwebtoken = "9"
+sha2 = "0.10"
+base64 = "0.22"
+reqwest = { workspace = true }

--- a/crates/agent-nexus/src/a2a/mod.rs
+++ b/crates/agent-nexus/src/a2a/mod.rs
@@ -40,7 +40,9 @@ pub async fn start_a2a_relay(store: Arc<SharedStore>) -> Result<Arc<A2ARelay>> {
     let relay = Arc::new(A2ARelay::new(store));
     let router = create_router(relay.clone());
 
-    let addr = std::env::var("A2A_RELAY_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
+    let addr = config::EnvConfig::from_env()
+        .map(|c| c.infra.a2a_relay_addr)
+        .unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     info!(
         addr = %addr,

--- a/crates/agent-nexus/src/hooks/jwt.rs
+++ b/crates/agent-nexus/src/hooks/jwt.rs
@@ -1,0 +1,132 @@
+// crates/agent-nexus/src/hooks/jwt.rs
+//! HS256 JWT verification for Coder agent lifecycle hook dispatches.
+//!
+//! Coder signs each hook request with the deployment-wide
+//! `CODER_CHAT_HOOK_SECRET` and sends the token in `Authorization: Bearer`.
+//! Per the gist/coder contract the consumer must check:
+//!   - signature (HS256 against the shared secret),
+//!   - `iss`,
+//!   - `aud` == the hook URL,
+//!   - `exp`,
+//!   - `jti` == `dispatch_id`,
+//!   - `body_sha256` == sha256 of the request body.
+//!
+//! This is the OpenFlows-side analogue of `codersdk/x/agenthooks`
+//! `agenthooks.NewHTTPHandler`.
+
+use anyhow::{anyhow, Context, Result};
+use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// The expected issuer Coder uses for hook JWTs.
+const EXPECTED_ISSUER: &str = "coder";
+
+/// Claims verified on the hook JWT.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HookClaims {
+    /// Emitted by Coder (expected "coder").
+    pub iss: String,
+    /// Audience — must equal the configured hook URL.
+    pub aud: String,
+    /// Expiry (unix seconds).
+    pub exp: usize,
+    /// JWT ID — must equal the `dispatch_id` in the payload.
+    pub jti: String,
+    /// Event type — must equal the body `type`.
+    #[serde(default)]
+    pub r#type: Option<String>,
+    /// Subject — must be `coder:chat:<chat_id>`.
+    #[serde(default)]
+    pub sub: Option<String>,
+    /// SHA-256 hex digest of the raw request body.
+    pub body_sha256: Option<String>,
+}
+
+/// Compute the hex SHA-256 of the raw request body for `body_sha256` checks.
+pub fn sha256_hex(body: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(body);
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(digest.len() * 2);
+    for b in digest {
+        out.push_str(&format!("{:02x}", b));
+    }
+    out
+}
+
+/// Verify the `Authorization: Bearer <jwt>` token against the shared secret
+/// and bind it to the actual request body + configured hook URL.
+///
+/// Returns the parsed claims on success.
+pub fn verify_hook_jwt(
+    auth_header: Option<&str>,
+    secret: &str,
+    expected_aud: &str,
+    dispatch_id: &str,
+    chat_id: &str,
+    event_type: &str,
+    body: &[u8],
+) -> Result<HookClaims> {
+    let header = auth_header
+        .and_then(|h| h.strip_prefix("Bearer "))
+        .context("missing Authorization: Bearer header")?;
+
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.set_issuer(&[EXPECTED_ISSUER]);
+    validation.set_audience(&[expected_aud]);
+    validation.validate_exp = true;
+
+    let key = DecodingKey::from_secret(secret.as_bytes());
+    let token = decode::<HookClaims>(header, &key, &validation)
+        .map_err(|e| anyhow!("hook JWT verification failed: {e}"))?;
+
+    let claims = token.claims;
+
+    // `jti` must equal the dispatch_id carried in the payload.
+    if !claims.jti.is_empty() && claims.jti != dispatch_id {
+        return Err(anyhow!(
+            "hook JWT jti `{}` does not match payload dispatch_id `{}`",
+            claims.jti,
+            dispatch_id
+        ));
+    }
+
+    // `type` (JWT) must equal the body event type.
+    if let Some(t) = &claims.r#type {
+        if t != event_type {
+            return Err(anyhow!(
+                "hook JWT type `{}` does not match payload type `{}`",
+                t,
+                event_type
+            ));
+        }
+    }
+
+    // `sub` must be `coder:chat:<chat_id>`.
+    if let Some(sub) = &claims.sub {
+        let expected_sub = format!("coder:chat:{chat_id}");
+        if sub != &expected_sub {
+            return Err(anyhow!(
+                "hook JWT sub `{}` does not match payload chat_id `{}`",
+                sub,
+                chat_id
+            ));
+        }
+    }
+
+    // `body_sha256` must match the actual request body (anti-replay /
+    // integrity for rewrites).
+    if let Some(claimed) = &claims.body_sha256 {
+        let actual = sha256_hex(body);
+        if !actual.eq_ignore_ascii_case(claimed) {
+            return Err(anyhow!(
+                "hook JWT body_sha256 mismatch (got `{}`, expected `{}`)",
+                actual,
+                claimed
+            ));
+        }
+    }
+
+    Ok(claims)
+}

--- a/crates/agent-nexus/src/hooks/mod.rs
+++ b/crates/agent-nexus/src/hooks/mod.rs
@@ -1,0 +1,32 @@
+// crates/agent-nexus/src/hooks/mod.rs
+//! Coder Agent Lifecycle Hooks — OpenFlows webhook consumer (experimental).
+//!
+//! Mirrors how Coder's `agent-lifecycle-hooks` experiment works (see
+//! coder/coder `docs/admin/setup/chat-lifecycle-hooks.md`). Coder `chatd`
+//! POSTs a JWT-signed lifecycle event to one deployment-wide webhook URL
+//! (`CODER_CHAT_HOOK_URL`) for each event; the consumer owns the audit trail.
+//!
+//! OpenFlows hosts this consumer inside the Controller (alongside the A2A
+//! relay). It verifies the HS256 JWT, observes events centrally, persists a
+//! durable log, and provides the seam to deny/rewrite `user_prompt_submit` /
+//! `pre_tool_use` — the centralized analogue of the in-workspace
+//! `orchestration/plugin/hooks/{role}/` shell hooks.
+//!
+//! Enablement (Coder side, deployment config):
+//!   CODER_EXPERIMENTS=agent-lifecycle-hooks
+//!   CODER_CHAT_HOOK_URL=http://<host>:3001/hooks/chat
+//!   CODER_CHAT_HOOK_SECRET=<>=32 random bytes>
+//! The OpenFlows consumer binds on `OPENFLOWS_HOOK_ADDR` (default 127.0.0.1:3001).
+
+mod jwt;
+mod server;
+mod simulate;
+mod types;
+
+pub use jwt::verify_hook_jwt;
+pub use server::{create_router, start_lifecycle_hook_server};
+pub use simulate::dispatch_simulated_event;
+pub use types::{HookDecision, HookEvent, HookPayload};
+
+#[cfg(test)]
+mod tests;

--- a/crates/agent-nexus/src/hooks/server.rs
+++ b/crates/agent-nexus/src/hooks/server.rs
@@ -1,0 +1,487 @@
+// crates/agent-nexus/src/hooks/server.rs
+//! Axum webhook consumer for Coder's experimental `agent-lifecycle-hooks`.
+//!
+//! Coder `chatd` POSTs a JWT-signed lifecycle event to
+//! `CODER_CHAT_HOOK_URL`. This module hosts that endpoint inside the
+//! OpenFlows Controller (the same process that hosts the A2A relay). It:
+//!
+//!   1. Verifies the HS256 JWT (signature, iss, aud, exp, jti, body_sha256).
+//!   2. Decodes the lifecycle event.
+//!   3. Observes it: logs centrally and persists a durable, tenant-namespaced
+//!      audit trail in Redis (mirroring the A2A audit model).
+//!   4. Applies policy for mutable events (`user_prompt_submit`,
+//!      `pre_tool_use`) — today a passthrough; the seam is where OpenFlows'
+//!      in-workspace PreToolUse/PreWrite policy could be centralized.
+//!
+//! This is the OpenFlows-side analogue of Coder's `scripts/agenthooks-server`
+//! reference consumer. It lets us turn the experiment on and *observe behaviour*
+//! before we decide how much policy to centralize.
+
+use super::jwt::verify_hook_jwt;
+use super::types::{HookDecision, HookEvent, HookPayload};
+use anyhow::{anyhow, Context, Result};
+use config::env::CoderHooksConfig;
+use axum::{
+    extract::State,
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    routing::post,
+    Json, Router,
+};
+use pocketflow_core::SharedStore;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use tracing::{debug, info, warn};
+
+/// Shared state for the hook consumer.
+#[derive(Clone)]
+pub struct HookServerState {
+    pub store: Arc<SharedStore>,
+    pub config: CoderHooksConfig,
+}
+
+/// Build the router serving the webhook endpoint.
+pub fn create_router(store: Arc<SharedStore>, config: CoderHooksConfig) -> Router {
+    Router::new()
+        .route("/hooks/chat", post(handle_hook))
+        .route("/hooks/health", axum::routing::get(handle_health))
+        .with_state(HookServerState { store, config })
+}
+
+async fn handle_health() -> &'static str {
+    "OpenFlows lifecycle hook consumer healthy"
+}
+
+/// Handle a single lifecycle hook dispatch from Coder.
+async fn handle_hook(
+    State(state): State<HookServerState>,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    let hook_url = match state.config.chat_hook_url.clone() {
+        Some(u) => u,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "hook consumer not enabled (CODER_CHAT_HOOK_URL unset)",
+            )
+                .into_response();
+        }
+    };
+    let secret = match state.config.chat_hook_secret.clone() {
+        Some(s) => s,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "hook consumer misconfigured (CODER_CHAT_HOOK_SECRET unset)",
+            )
+                .into_response();
+        }
+    };
+
+    // Parse the payload first so we can bind jti for the signature check.
+    let payload: HookPayload = match serde_json::from_slice(&body) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(error = %e, "Hook consumer: malformed JSON body");
+            return (StatusCode::BAD_REQUEST, "invalid JSON body").into_response();
+        }
+    };
+    let dispatch_id = payload.meta.dispatch_id.clone();
+    let chat_id = payload.meta.chat_id.clone();
+    let event_str = match serde_json::to_string(&payload.event) {
+        Ok(s) => s.trim_matches('"').to_string(),
+        Err(_) => "unknown".to_string(),
+    };
+
+    // Build the audit key BEFORE verifying so a failed signature is still
+    // observable (we only persist after verification, below).
+    debug!(
+        dispatch_id = %dispatch_id,
+        event = ?payload.event,
+        "Hook consumer: received dispatch"
+    );
+
+    // Verify the JWT.
+    let auth = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok());
+    if let Err(e) = verify_hook_jwt(
+        auth,
+        &secret,
+        &hook_url,
+        &dispatch_id,
+        &chat_id,
+        &event_str,
+        &body,
+    ) {
+        warn!(error = %e, "Hook consumer: JWT verification failed");
+        // Fail closed: coder treats a failed consumer as chat error state.
+        return (StatusCode::UNAUTHORIZED, format!("{e:#}")).into_response();
+    }
+
+    info!(
+        dispatch_id = %dispatch_id,
+        chat_id = %chat_id,
+        event = ?payload.event,
+        client = ?payload.meta.client,
+        "OpenFlows observed Coder lifecycle hook event"
+    );
+
+    // Persist a durable audit trail (best-effort; never fail the dispatch).
+    let _ = persist_audit(&state.store, &payload).await;
+
+    // Apply policy, then serialize the decision into Coder's response schema:
+    //   allow/deny via permission.decision, rewrite via permission.input_override,
+    //   human/machine explanation via user_message / model_context.
+    //
+    // A policy decision (deny or rewrite) is carried in the JSON body and
+    // returned with a 200 so Coder reads it as a deliberate decision, NOT a
+    // dispatch failure. Non-2xx is reserved for real dispatch failures
+    // (bad JWT / malformed body) earlier in this handler, which fail closed.
+    let decision = apply_policy(&payload);
+    let body = decision_to_response(&decision);
+    (StatusCode::OK, Json(body)).into_response()
+}
+
+/// Convert the internal [`HookDecision`] into Coder's response-body schema.
+/// A denial carries `permission.decision=deny`; a rewrite carries
+/// `permission.decision=allow` with `permission.input_override`; an
+/// observation yields an empty JSON object (equivalent to an empty body).
+fn decision_to_response(decision: &HookDecision) -> serde_json::Value {
+    if !decision.deny && decision.rewrite.is_none() {
+        // No-op: Coder accepts an empty JSON object.
+        return serde_json::json!({});
+    }
+    if decision.deny {
+        let mut permission = serde_json::json!({ "decision": "deny" });
+        if let Some(reason) = &decision.reason {
+            permission["user_message"] = serde_json::Value::String(reason.clone());
+        }
+        return serde_json::json!({ "permission": permission });
+    }
+    // allow + input_override (rewrite). input_override must carry the full,
+    // canonical replacement for the tool input or prompt.
+    if let Some(rewrite) = &decision.rewrite {
+        return serde_json::json!({
+            "permission": {
+                "decision": "allow",
+                "input_override": rewrite
+            }
+        });
+    }
+    serde_json::json!({})
+}
+
+/// Centralized policy seam. Mutable events can be denied or rewritten here.
+///
+/// This is the server-side twin of the in-workspace `pre_bash_guard.sh` /
+/// `pre_write_check.sh` scripts, but enforced in the trusted control plane so
+/// a workspace cannot bypass it. Rules:
+///   - Any non-mutable event → observe (no decision).
+///   - `pre_tool_use` → inspect `tool_name` + `tool_input`, then either allow
+///     unchanged, deny, or return an `input_override` (rewrite).
+///   - `user_prompt_submit` → deny rewriting that would drop attachments
+///     (see D4 in the feedback doc); by default observe.
+///
+/// Deny/override logic mirrors forge `pre_bash_guard.sh`: destructive shell,
+/// force-push to default branch, direct Redis, control-plane mutation.
+fn apply_policy(payload: &HookPayload) -> HookDecision {
+    match payload.event {
+        HookEvent::PreToolUse => decide_pre_tool_use(&payload.data),
+        HookEvent::UserPromptSubmit => decide_user_prompt(&payload.data),
+        _ => HookDecision::observe(),
+    }
+}
+
+/// Decision for a `pre_tool_use` dispatch.
+fn decide_pre_tool_use(data: &Value) -> HookDecision {
+    let tool_name = data
+        .get("tool_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_lowercase();
+    let tool_input = data.get("tool_input").unwrap_or(&Value::Null);
+
+    // Only gate tools that carry a command/filename argument.
+    match tool_name.as_str() {
+        "bash" | "sh" | "shell" | "execute" | "exec" => {
+            let cmd = extract_command(tool_input).unwrap_or_default();
+            classify_command(&cmd)
+        }
+        "write" | "edit" | "create" | "patch" => {
+            // Prevent writes outside the workspace root.
+            let path = tool_input
+                .get("path")
+                .or_else(|| tool_input.get("file_path"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            if is_outside_workspace(&path) {
+                return HookDecision::deny(format!(
+                    "openflows policy: write outside workspace (`{path}`) is blocked"
+                ));
+            }
+            // Override example: force benign edit tool flags (rewrite demo).
+            HookDecision::observe()
+        }
+        _ => {
+            // Unknown / MCP / dynamic tool: no built-in duplicate-key precheck
+            // exists server-side (D4), so allow and rely on the workspace.
+            debug!(tool = tool_name, "Hook consumer: ungated tool passed through");
+            HookDecision::observe()
+        }
+    }
+}
+
+/// Decision for a `user_prompt_submit` dispatch. Today we only guard against
+/// an override that would silently drop file attachments; otherwise observe.
+fn decide_user_prompt(data: &Value) -> HookDecision {
+    let parts = data.get("parts");
+    if let Some(parts) = parts {
+        if let Some(arr) = parts.as_array() {
+            let non_text = arr
+                .iter()
+                .filter(|p| p.get("type").and_then(|t| t.as_str()) != Some("text"))
+                .count();
+            if non_text > 0 {
+                // If we were to override the prompt, we must NOT drop these.
+                // We observe (don't override) so attachments survive.
+                debug!(
+                    non_text_parts = non_text,
+                    "Hook consumer: prompt has attachments; not overriding to avoid dropping them"
+                );
+                return HookDecision::observe();
+            }
+        }
+    }
+    HookDecision::observe()
+}
+
+/// Pull the shell command out of a tool_input, tolerating the common shapes
+/// (`command`, `argv`, or plain string payload).
+fn extract_command(tool_input: &Value) -> Option<String> {
+    if let Some(c) = tool_input.get("command").and_then(|v| v.as_str()) {
+        return Some(c.to_string());
+    }
+    if let Some(argv) = tool_input.get("argv").and_then(|v| v.as_array()) {
+        return Some(
+            argv.iter()
+                .filter_map(|v| v.as_str())
+                .collect::<Vec<_>>()
+                .join(" "),
+        );
+    }
+    if let Some(s) = tool_input.as_str() {
+        return Some(s.to_string());
+    }
+    None
+}
+
+/// Classify a shell command into a decision. Ported from forge
+/// `pre_bash_guard.sh`.
+fn classify_command(cmd: &str) -> HookDecision {
+    let deny = |reason: String| HookDecision::deny(reason);
+
+    if cmd.contains("rm -rf /") || cmd.contains("rm -rf /*") {
+        return deny("recursive delete of filesystem root".into());
+    }
+    if (cmd.contains("git push") && cmd.contains("--force") && cmd.contains("main"))
+        || (cmd.contains("git push") && (cmd.contains("-f") || cmd.contains("--force")) && cmd.contains("master"))
+    {
+        return deny("force-push to default branch".into());
+    }
+    if cmd.contains("redis-cli") {
+        return deny("direct Redis access — use openflows-harness for all coordination".into());
+    }
+    if cmd.contains("coder templates") || cmd.contains("coder delete") || cmd.contains("coder server") {
+        return deny("control-plane mutation from a worker workspace".into());
+    }
+
+    // Override example: wrap risky-but-allowed git pushes to avoid interactive
+    // prompts hanging the loop (rewrite demo — shows the mechanism).
+    if cmd.trim_start().starts_with("git push") {
+        let override_cmd = format!(
+            "GIT_TERMINAL_PROMPT=0 git -c core.askpass=true {}",
+            cmd.trim()
+        );
+        return HookDecision {
+            deny: false,
+            reason: None,
+            rewrite: Some(serde_json::json!({ "command": override_cmd })),
+        };
+    }
+
+    HookDecision::observe()
+}
+
+/// True when the given path is absolute and points outside the workspace.
+fn is_outside_workspace(path: &str) -> bool {
+    let trimmed = path.trim_start_matches('~').trim_start_matches("./");
+    // Absolute paths referencing system roots are treated as outside unless
+    // they clearly live under a /home/coder/workspace or /workspace root.
+    if trimmed.starts_with('/') {
+        let outside = [
+            "/home/coder/workspace",
+            "/home/coder",
+            "/workspace",
+            "/home/",
+            ".",
+        ]
+        .iter()
+        .all(|root| !trimmed.starts_with(root));
+        return outside;
+    }
+    false
+}
+
+/// Write a tenant-namespaced, durable audit record for a hook event.
+async fn persist_audit(store: &SharedStore, payload: &HookPayload) -> Result<()> {
+    let mut events: Vec<Value> = store.get_typed("_hook_events_tail").await.unwrap_or_default();
+    events.push(json!({
+        "dispatch_id": payload.meta.dispatch_id,
+        "event": payload.event,
+        "chat_id": payload.meta.chat_id,
+        "owner_id": payload.meta.owner_id,
+        "workspace_id": payload.meta.workspace_id,
+        "client": payload.meta.client,
+        "data": payload.data,
+        "ts": chrono::Utc::now().timestamp(),
+    }));
+    if events.len() > 500 {
+        let drop = events.len() - 500;
+        events.drain(0..drop);
+    }
+    store.set("_hook_events_tail", serde_json::to_value(events)?).await;
+    Ok(())
+}
+
+/// Start the hook consumer HTTP server as a background task.
+///
+/// Only binds when the experiment + config indicate it is enabled. Returns
+/// `Ok(None)` when disabled so the controller startup stays explicit.
+pub async fn start_lifecycle_hook_server(
+    store: Arc<SharedStore>,
+    config: CoderHooksConfig,
+) -> Result<Option<()>> {
+    if !config.enabled() {
+        info!(
+            "Coder agent lifecycle hooks experiment not enabled; hook consumer not started \
+             (set CODER_EXPERIMENTS=agent-lifecycle-hooks and CODER_CHAT_HOOK_URL)"
+        );
+        return Ok(None);
+    }
+    if config.chat_hook_secret.as_deref().map(str::len).unwrap_or(0) < 32 {
+        return Err(anyhow!(
+            "CODER_CHAT_HOOK_SECRET must be at least 32 bytes to verify HS256 hook JWTs"
+        ));
+    }
+
+    let router = create_router(store, config.clone());
+    let addr = config.hook_addr.clone();
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .with_context(|| format!("failed to bind hook consumer on {addr}"))?;
+    info!(
+        addr = %addr,
+        hook_url = %config.chat_hook_url.clone().unwrap_or_default(),
+        "OpenFlows lifecycle hook consumer starting"
+    );
+
+    tokio::spawn(async move {
+        if let Err(e) = axum::serve(listener, router).await {
+            tracing::error!(error = %e, "Lifecycle hook consumer HTTP server error");
+        }
+    });
+
+    Ok(Some(()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn tool(tool_name: &str, input: Value) -> Value {
+        json!({ "tool_name": tool_name, "tool_input": input })
+    }
+
+    #[test]
+    fn allows_safe_command() {
+        let data = tool("Bash", json!({ "command": "openflows-harness status set building" }));
+        let d = decide_pre_tool_use(&data);
+        assert!(!d.deny);
+        assert!(d.rewrite.is_none());
+    }
+
+    #[test]
+    fn denies_destructive_command() {
+        let data = tool("Bash", json!({ "command": "rm -rf /" }));
+        let d = decide_pre_tool_use(&data);
+        assert!(d.deny);
+    }
+
+    #[test]
+    fn denies_force_push_to_main() {
+        let data = tool("Bash", json!({ "command": "git push --force origin main" }));
+        let d = decide_pre_tool_use(&data);
+        assert!(d.deny);
+    }
+
+    #[test]
+    fn denies_redis_cli() {
+        let data = tool("Bash", json!({ "command": "redis-cli flushall" }));
+        let d = decide_pre_tool_use(&data);
+        assert!(d.deny);
+    }
+
+    #[test]
+    fn rewrite_wraps_git_push() {
+        let data = tool("Bash", json!({ "command": "git push origin feature/x" }));
+        let d = decide_pre_tool_use(&data);
+        assert!(!d.deny);
+        let rewrite = d.rewrite.expect("git push should be rewritten");
+        let cmd = rewrite["command"].as_str().unwrap();
+        assert!(cmd.starts_with("GIT_TERMINAL_PROMPT=0"));
+    }
+
+    #[test]
+    fn denies_workspace_escape_write() {
+        let data = tool("Write", json!({ "path": "/etc/passwd" }));
+        let d = decide_pre_tool_use(&data);
+        assert!(d.deny);
+    }
+
+    #[test]
+    fn allows_workspace_write() {
+        let data = tool("Write", json!({ "path": "/home/coder/workspace/src/main.rs" }));
+        let d = decide_pre_tool_use(&data);
+        assert!(!d.deny);
+    }
+
+    #[test]
+    fn deny_serializes_to_coder_schema() {
+        let d = HookDecision::deny("blocked");
+        let v = decision_to_response(&d);
+        assert_eq!(v["permission"]["decision"], "deny");
+        assert_eq!(v["permission"]["user_message"], "blocked");
+    }
+
+    #[test]
+    fn rewrite_serializes_as_input_override() {
+        let d = HookDecision {
+            deny: false,
+            reason: None,
+            rewrite: Some(json!({ "command": "echo hi" })),
+        };
+        let v = decision_to_response(&d);
+        assert_eq!(v["permission"]["decision"], "allow");
+        assert_eq!(v["permission"]["input_override"]["command"], "echo hi");
+    }
+
+    #[test]
+    fn observe_serializes_empty() {
+        let v = decision_to_response(&HookDecision::observe());
+        assert!(v.as_object().map(|o| o.is_empty()).unwrap_or(false));
+    }
+}

--- a/crates/agent-nexus/src/hooks/simulate.rs
+++ b/crates/agent-nexus/src/hooks/simulate.rs
@@ -1,0 +1,146 @@
+// crates/agent-nexus/src/hooks/simulate.rs
+//! Simulation / test emitter for the Coder agent lifecycle hook consumer.
+//!
+//! Coder's `chatd` signs hook dispatches with HS256 using the deployment
+//! secret and POSTs them to `CODER_CHAT_HOOK_URL`. This module reproduces that
+//! signing and delivery so you can exercise the OpenFlows consumer end-to-end
+//! without a Coder server. It builds a JWT that mirrors Coder's contract:
+//! `iss=coder`, `aud=CODER_CHAT_HOOK_URL`, `exp`, `jti=dispatch_id`,
+//! `body_sha256`, plus a `sub` of the form `coder:chat:<chat_id>` and a `type`
+//! claim matching the body event.
+
+use super::jwt::sha256_hex;
+use super::types::HookEvent;
+use anyhow::{anyhow, Context, Result};
+use chrono::Utc;
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use serde_json::{json, Value};
+
+/// Sign a lifecycle-hook JWT exactly like Coder's `chatd`.
+pub fn sign_hook_jwt(
+    secret: &str,
+    hook_url: &str,
+    dispatch_id: &str,
+    chat_id: &str,
+    event: &str,
+    body_sha256: &str,
+) -> Result<String> {
+    let claims = json!({
+        "iss": "coder",
+        "aud": hook_url,
+        "sub": format!("coder:chat:{chat_id}"),
+        "exp": (Utc::now().timestamp() as usize) + 3600,
+        "nbf": (Utc::now().timestamp() as usize) - 60,
+        "jti": dispatch_id,
+        "type": event,
+        "body_sha256": body_sha256,
+    });
+    encode(
+        &Header::new(Algorithm::HS256),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .context("failed to sign hook JWT")
+}
+
+/// Build a sample event body for a given event name (mirrors Coder shapes).
+pub fn build_event_body(event: &str, chat_id: &str, dispatch_id: &str) -> Result<Value> {
+    let parsed: HookEvent = serde_json::from_value(json!(event))
+        .map_err(|_| anyhow!("unknown hook event `{event}`"))?;
+
+    let (data, schema) = match parsed {
+        HookEvent::SessionStart => {
+            (json!({"source": "startup"}), json!({"schema_version": 1}))
+        }
+        HookEvent::UserPromptSubmit => (
+            json!({"prompt": "Implement the ticket and open a PR.", "parts": []}),
+            json!({"schema_version": 1}),
+        ),
+        HookEvent::PreToolUse => (
+            json!({
+                "tool_use_id": "tool-1",
+                "tool_name": "Bash",
+                "tool_input": {"command": "openflows-harness status set building"}
+            }),
+            json!({"schema_version": 1}),
+        ),
+        HookEvent::PostToolUse => (
+            json!({
+                "tool_use_id": "tool-1",
+                "tool_name": "Bash",
+                "tool_response": {"exit_code": 0, "stdout": "ok"}
+            }),
+            json!({"schema_version": 1}),
+        ),
+        HookEvent::PreCompact | HookEvent::PostCompact | HookEvent::Stop => {
+            (json!({}), json!({"schema_version": 1}))
+        }
+    };
+
+    let meta = json!({
+        "dispatch_id": dispatch_id,
+        "chat_id": chat_id,
+        "owner_id": "00000000-0000-0000-0000-000000000000",
+        "workspace_id": "00000000-0000-0000-0000-000000000000",
+        "turn_id": "00000000-0000-0000-0000-000000000000"
+    });
+    let meta = meta.merge(&schema);
+
+    Ok(json!({
+        "type": event,
+        "meta": meta,
+        "data": data
+    }))
+}
+
+/// Internal helper to merge two JSON objects (used above for meta defaults).
+trait Merge {
+    fn merge(self, other: &Value) -> Value;
+}
+
+impl Merge for Value {
+    fn merge(self, other: &Value) -> Value {
+        let mut base = self;
+        if let (Some(b), Some(o)) = (base.as_object_mut(), other.as_object()) {
+            for (k, v) in o {
+                b.insert(k.clone(), v.clone());
+            }
+        }
+        base
+    }
+}
+
+/// POST a signed lifecycle event to the configured hook URL.
+///
+/// Returns the HTTP status line of the consumer response for inspection.
+pub async fn dispatch_simulated_event(
+    hook_url: &str,
+    secret: &str,
+    event: &str,
+    chat_id: &str,
+    dispatch_id: &str,
+) -> Result<(u16, String)> {
+    let body = build_event_body(event, chat_id, dispatch_id)?;
+    let body_bytes = serde_json::to_vec(&body).context("failed to serialize event body")?;
+    let digest = sha256_hex(&body_bytes);
+
+    let token = sign_hook_jwt(secret, hook_url, dispatch_id, chat_id, event, &digest)?;
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .context("failed to build http client")?;
+
+    let resp = client
+        .post(hook_url)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(body_bytes)
+        .send()
+        .await
+        .with_context(|| format!("POST to {hook_url} failed"))?;
+
+    let status = resp.status().as_u16();
+    let text = resp.text().await.unwrap_or_default();
+    Ok((status, text))
+}

--- a/crates/agent-nexus/src/hooks/tests.rs
+++ b/crates/agent-nexus/src/hooks/tests.rs
@@ -1,0 +1,246 @@
+// crates/agent-nexus/src/hooks/tests.rs
+//! Unit + end-to-end tests for the lifecycle-hook consumer.
+
+use super::jwt::{sha256_hex, verify_hook_jwt};
+use super::types::{HookDecision, HookEvent, HookPayload};
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use serde_json::{json, Value};
+
+const SECRET: &str = "a-very-long-secret-of-at-least-thirty-two-bytes!";
+const URL: &str = "http://localhost:3001/hooks/chat";
+const CHAT: &str = "chat-abc";
+const EVENT: &str = "session_start";
+
+fn sign(secret: &str, claims: &Value) -> String {
+    encode(
+        &Header::new(Algorithm::HS256),
+        claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .unwrap()
+}
+
+fn make_payload(dispatch_id: &str) -> Vec<u8> {
+    serde_json::to_vec(&json!({
+        "type": EVENT,
+        "meta": {
+            "dispatch_id": dispatch_id,
+            "schema_version": 1,
+            "chat_id": CHAT,
+            "owner_id": "owner-1"
+        },
+        "data": {"source": "startup"}
+    }))
+    .unwrap()
+}
+
+fn token_for(dispatch_id: &str, body: &[u8]) -> String {
+    sign(
+        SECRET,
+        &json!({
+            "iss": "coder",
+            "aud": URL,
+            "exp": 4_000_000_000usize,
+            "jti": dispatch_id,
+            "type": EVENT,
+            "sub": format!("coder:chat:{}", CHAT),
+            "body_sha256": sha256_hex(body),
+        }),
+    )
+}
+
+fn verify(secret: &str, token: &str, dispatch_id: &str, body: &[u8]) -> anyhow::Result<()> {
+    verify_hook_jwt(
+        Some(&format!("Bearer {token}")),
+        secret,
+        URL,
+        dispatch_id,
+        CHAT,
+        EVENT,
+        body,
+    )?;
+    Ok(())
+}
+
+#[test]
+fn verifies_a_valid_hs256_jwt() {
+    let body = make_payload("dispatch-1");
+    let token = token_for("dispatch-1", &body);
+    verify(SECRET, &token, "dispatch-1", &body).expect("valid JWT should verify");
+}
+
+#[test]
+fn rejects_missing_bearer_header() {
+    let body = make_payload("d1");
+    assert!(verify_hook_jwt(None, SECRET, URL, "d1", CHAT, EVENT, &body).is_err());
+}
+
+#[test]
+fn rejects_wrong_secret() {
+    let wrong = "a-different-secret-that-is-also-long-enough!!!";
+    let body = make_payload("d1");
+    let token = sign(
+        wrong,
+        &json!({
+            "iss": "coder",
+            "aud": URL,
+            "exp": 4_000_000_000usize,
+            "jti": "d1",
+            "type": EVENT,
+            "sub": format!("coder:chat:{}", CHAT),
+            "body_sha256": sha256_hex(&body),
+        }),
+    );
+    assert!(verify(SECRET, &token, "d1", &body).is_err());
+}
+
+#[test]
+fn rejects_dispatch_id_mismatch() {
+    let body = make_payload("d1");
+    assert!(verify(SECRET, &token_for("OTHER", &body), "d1", &body).is_err());
+}
+
+#[test]
+fn rejects_expired_token() {
+    let body = make_payload("d1");
+    let token = sign(
+        SECRET,
+        &json!({
+            "iss": "coder",
+            "aud": URL,
+            "exp": 1usize,
+            "jti": "d1",
+            "type": EVENT,
+            "sub": format!("coder:chat:{}", CHAT),
+            "body_sha256": sha256_hex(&body),
+        }),
+    );
+    assert!(verify(SECRET, &token, "d1", &body).is_err());
+}
+
+#[test]
+fn rejects_body_sha256_mismatch() {
+    let body = make_payload("d1");
+    let token = sign(
+        SECRET,
+        &json!({
+            "iss": "coder",
+            "aud": URL,
+            "exp": 4_000_000_000usize,
+            "jti": "d1",
+            "type": EVENT,
+            "sub": format!("coder:chat:{}", CHAT),
+            "body_sha256": "deadbeef",
+        }),
+    );
+    assert!(verify(SECRET, &token, "d1", &body).is_err());
+}
+
+#[test]
+fn rejects_type_claim_mismatch() {
+    let body = make_payload("d1");
+    let token = sign(
+        SECRET,
+        &json!({
+            "iss": "coder",
+            "aud": URL,
+            "exp": 4_000_000_000usize,
+            "jti": "d1",
+            "type": "stop",
+            "sub": format!("coder:chat:{}", CHAT),
+            "body_sha256": sha256_hex(&body),
+        }),
+    );
+    assert!(verify(SECRET, &token, "d1", &body).is_err());
+}
+
+#[test]
+fn rejects_chat_subject_mismatch() {
+    let body = make_payload("d1");
+    let token = sign(
+        SECRET,
+        &json!({
+            "iss": "coder",
+            "aud": URL,
+            "exp": 4_000_000_000usize,
+            "jti": "d1",
+            "type": EVENT,
+            "sub": "coder:chat:OTHER-CHAT",
+            "body_sha256": sha256_hex(&body),
+        }),
+    );
+    assert!(verify(SECRET, &token, "d1", &body).is_err());
+}
+
+#[test]
+fn mutable_events_allow_deny_rewrite() {
+    assert!(HookEvent::UserPromptSubmit.is_mutable());
+    assert!(HookEvent::PreToolUse.is_mutable());
+    assert!(!HookEvent::SessionStart.is_mutable());
+    assert!(!HookEvent::Stop.is_mutable());
+
+    let deny = HookDecision::deny("blocked by policy");
+    assert!(deny.deny);
+    assert_eq!(deny.reason.as_deref(), Some("blocked by policy"));
+
+    let observe = HookDecision::observe();
+    assert!(!observe.deny);
+}
+
+#[test]
+fn parses_hook_payload_real_coder_envelope() {
+    let raw = json!({
+        "type": "pre_tool_use",
+        "meta": {
+            "dispatch_id": "dis-1",
+            "schema_version": 1,
+            "chat_id": "c-1",
+            "owner_id": "o-1",
+            "workspace_id": "ws-1",
+            "turn_id": "t-1"
+        },
+        "data": {"tool_use_id": "tu-1", "tool_name": "Bash", "tool_input": {"command": "rm -rf /"}}
+    });
+    let payload: HookPayload = serde_json::from_value(raw).unwrap();
+    assert_eq!(payload.event, HookEvent::PreToolUse);
+    assert!(payload.event.is_mutable());
+    assert_eq!(payload.meta.chat_id, "c-1");
+    assert_eq!(payload.meta.dispatch_id, "dis-1");
+    assert_eq!(payload.data["tool_name"], "Bash");
+}
+
+#[tokio::test]
+async fn consumer_accepts_signed_dispatch_end_to_end() {
+    use super::server::create_router;
+    use super::simulate::dispatch_simulated_event;
+    use config::env::CoderHooksConfig;
+    use pocketflow_core::SharedStore;
+    use std::sync::Arc;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let hook_url = format!("http://{addr}/hooks/chat");
+
+    let config = CoderHooksConfig {
+        chat_hook_url: Some(hook_url.clone()),
+        chat_hook_secret: Some(SECRET.to_string()),
+        chat_hook_timeout_ms: 1500,
+        chat_hook_enabled: true,
+        chat_hook_allow_insecure: true,
+        hook_addr: "127.0.0.1:0".to_string(),
+    };
+
+    let store = Arc::new(SharedStore::new_in_memory());
+    let router = create_router(store, config);
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let (status, body) =
+        dispatch_simulated_event(&hook_url, SECRET, "session_start", CHAT, "dis-abc")
+            .await
+            .expect("dispatch should succeed");
+    assert_eq!(status, 200, "consumer should accept a valid signed dispatch: {body}");
+}

--- a/crates/agent-nexus/src/hooks/types.rs
+++ b/crates/agent-nexus/src/hooks/types.rs
@@ -1,0 +1,127 @@
+// crates/agent-nexus/src/hooks/types.rs
+//! Wire types for Coder's experimental `agent-lifecycle-hooks`.
+//!
+//! Mirrors `codersdk/x/agenthooks/types.go` event lifecycle. Coder `chatd`
+//! POSTs one of these to the deployment-wide webhook URL at each lifecycle
+//! event. A consumer may observe every event and may **deny or rewrite** the
+//! mutable ones (`user_prompt_submit`, `pre_tool_use`).
+//!
+//! Event names match Claude Code hooks (session_start, pre_tool_use, ...); the
+//! difference is transport: Coder-side hooks are server-side, deployment-wide
+//! HTTP POSTs, whereas OpenFlows' existing `orchestration/plugin/hooks/{role}/`
+//! are client-side shell scripts executed inside each agent workspace.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// The lifecycle events Coder can dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HookEvent {
+    /// A chat starts, resumes, or clears. Not mutable.
+    SessionStart,
+    /// A user or `spawn_agent` submits a prompt. Mutable (may deny/rewrite).
+    UserPromptSubmit,
+    /// Before a tool runs. Mutable (may deny/rewrite).
+    PreToolUse,
+    /// After a tool returns. Not mutable.
+    PostToolUse,
+    /// Before context compaction. Not mutable.
+    PreCompact,
+    /// After context compaction. Not mutable.
+    PostCompact,
+    /// The model ends a turn. Not mutable.
+    Stop,
+}
+
+impl HookEvent {
+    /// Whether the consumer may return a deny/rewrite decision for this event.
+    pub fn is_mutable(&self) -> bool {
+        matches!(self, HookEvent::UserPromptSubmit | HookEvent::PreToolUse)
+    }
+}
+
+/// The signed envelope Coder sends in the webhook request body.
+///
+/// Coder's real wire shape is `{ "type", "meta", "data" }`:
+///   - `type`  — the lifecycle event name (mirrored in the JWT `type` claim),
+///   - `meta`  — `dispatch_id`, `schema_version`, `chat_id`, `owner_id`,
+///     optional `workspace_id` / `turn_id`, and for subagent chats
+///     `parent_chat_id` / `root_chat_id`,
+///   - `data`  — event-specific fields.
+#[derive(Debug, Clone, Deserialize)]
+pub struct HookPayload {
+    /// Which lifecycle event fired (matches JWT `type` claim).
+    #[serde(rename = "type")]
+    pub event: HookEvent,
+    /// Dispatch envelope (identifiers the JWT binds to).
+    pub meta: HookMeta,
+    /// Free-form event context (tool name/input for tool events, prompt body
+    /// for user_prompt_submit, etc.).
+    #[serde(default)]
+    pub data: Value,
+}
+
+/// Identifiers Coder attaches to every dispatch (mirrors `meta`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct HookMeta {
+    /// ID of the dispatch (dedupe transport retries; must equal JWT `jti`).
+    #[serde(default)]
+    pub dispatch_id: String,
+    /// Wire schema version (current `1`).
+    #[serde(default)]
+    pub schema_version: u32,
+    /// Chat the event belongs to (also the `sub` suffix in the JWT).
+    #[serde(default)]
+    pub chat_id: String,
+    /// Owner of the chat.
+    #[serde(default)]
+    pub owner_id: String,
+    /// Optional workspace the event occurred in.
+    #[serde(default)]
+    pub workspace_id: Option<String>,
+    /// Optional turn the event belongs to.
+    #[serde(default)]
+    pub turn_id: Option<String>,
+    /// Present for subagent chats (correlate a subagent subtree).
+    #[serde(default)]
+    pub parent_chat_id: Option<String>,
+    /// Present for subagent chats (root conversation).
+    #[serde(default)]
+    pub root_chat_id: Option<String>,
+    /// Client label, when Coder provides one.
+    #[serde(default)]
+    pub client: Option<String>,
+}
+
+/// Consumer decision returned for mutable events. For non-mutable events the
+/// body is ignored and the event is observed only.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct HookDecision {
+    /// Whether to deny the action. Only honoured for `user_prompt_submit`
+    /// and `pre_tool_use`.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub deny: bool,
+    /// Optional human-readable reason surfaced for deny decisions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Optional rewritten context/message body returned to the agent loop.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rewrite: Option<Value>,
+}
+
+impl HookDecision {
+    /// An observation-only (no-op) decision.
+    pub fn observe() -> Self {
+        Self::default()
+    }
+
+    /// A denial decision with a reason.
+    pub fn deny(reason: impl Into<String>) -> Self {
+        Self {
+            deny: true,
+            reason: Some(reason.into()),
+            rewrite: None,
+        }
+    }
+}

--- a/crates/agent-nexus/src/lib.rs
+++ b/crates/agent-nexus/src/lib.rs
@@ -25,6 +25,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{debug, error, info, warn};
 
 pub mod a2a;
+pub mod hooks;
 
 /// Persona loaded from a `.agent.md` YAML frontmatter block.
 /// (Inlined from the deleted agent-client crate.)

--- a/crates/agent-nexus/src/lib.rs
+++ b/crates/agent-nexus/src/lib.rs
@@ -272,21 +272,45 @@ impl NexusNode {
         registry.resolve_github_token("nexus")
     }
 
+    /// Best-effort GitHub token from the centralized config (`GITHUB_TOKEN`),
+    /// falling back to the `/tmp/github_token` file. Returns `None` when
+    /// neither is available so callers can decide how to degrade.
+    fn resolve_github_token_from_env_or_file(&self) -> Option<String> {
+        config::EnvConfig::from_env()
+            .ok()
+            .and_then(|e| e.github.token)
+            .filter(|t| !t.is_empty())
+            .or_else(|| {
+                std::fs::read_to_string("/tmp/github_token")
+                    .ok()
+                    .map(|t| t.trim().to_string())
+                    .filter(|t| !t.is_empty())
+            })
+    }
+
     fn load_registry(&self) -> Result<Registry> {
         if self.registry_path.exists() {
             return Registry::load(&self.registry_path);
         }
 
-        if let Ok(path) = std::env::var("OPENFLOWS_REGISTRY_PATH") {
+        let tenant = config::EnvConfig::from_env().ok();
+
+        if let Some(path) = tenant
+            .as_ref()
+            .and_then(|t| t.tenant.registry_path.as_deref())
+        {
             let path = PathBuf::from(path);
             if path.exists() {
                 return Registry::load(path);
             }
         }
 
-        if let Ok(content) = std::env::var("OPENFLOWS_REGISTRY_JSON") {
-            let registry: Registry = serde_json::from_str(&content)
-                .context("Failed to parse OPENFLOWS_REGISTRY_JSON")?;
+        if let Some(content) = tenant
+            .as_ref()
+            .and_then(|t| t.tenant.registry_json.as_deref())
+        {
+            let registry: Registry =
+                serde_json::from_str(content).context("Failed to parse OPENFLOWS_REGISTRY_JSON")?;
             return Ok(registry);
         }
 
@@ -312,7 +336,10 @@ impl NexusNode {
     fn load_skills_for_role(&self, role: &str) -> String {
         let mut skills = Vec::new();
 
-        if let Ok(reg_json) = std::env::var("OPENFLOWS_REGISTRY_JSON") {
+        if let Some(reg_json) = config::EnvConfig::from_env()
+            .ok()
+            .and_then(|e| e.tenant.registry_json)
+        {
             if let Ok(registry) = serde_json::from_str::<config::Registry>(&reg_json) {
                 if let Some(entry) = registry.get(role) {
                     for skill_name in &entry.skills {
@@ -347,15 +374,12 @@ Before significant work, read the relevant skill file to understand the workflow
 
         let token = match self.resolve_github_token() {
             Ok(t) if !t.is_empty() => t,
-            Ok(_) | Err(_) => match std::env::var("GITHUB_TOKEN") {
-                Ok(t) if !t.is_empty() => t,
-                Ok(_) | Err(_) => match std::fs::read_to_string("/tmp/github_token") {
-                    Ok(t) if !t.trim().is_empty() => t.trim().to_string(),
-                    Ok(_) | Err(_) => {
-                        warn!("GitHub token not configured, skipping issue sync");
-                        return Ok(());
-                    }
-                },
+            Ok(_) | Err(_) => match self.resolve_github_token_from_env_or_file() {
+                Some(t) => t,
+                None => {
+                    warn!("GitHub token not configured, skipping issue sync");
+                    return Ok(());
+                }
             },
         };
 
@@ -418,21 +442,15 @@ Before significant work, read the relevant skill file to understand the workflow
 
         let token = match self.resolve_github_token() {
             Ok(t) => t,
-            Err(_) => match std::env::var("GITHUB_TOKEN") {
-                Ok(t) if !t.is_empty() => {
-                    info!("Using GITHUB_TOKEN env var for PR sync");
+            Err(_) => match self.resolve_github_token_from_env_or_file() {
+                Some(t) => {
+                    info!("Using GITHUB_TOKEN env var / token file for PR sync");
                     t
                 }
-                Ok(_) | Err(_) => match std::fs::read_to_string("/tmp/github_token") {
-                    Ok(t) if !t.trim().is_empty() => {
-                        info!("Using /tmp/github_token file for PR sync");
-                        t.trim().to_string()
-                    }
-                    Ok(_) | Err(_) => {
-                        warn!("GitHub token not configured, skipping PR sync");
-                        return Ok(());
-                    }
-                },
+                None => {
+                    warn!("GitHub token not configured, skipping PR sync");
+                    return Ok(());
+                }
             },
         };
 
@@ -741,12 +759,13 @@ Before significant work, read the relevant skill file to understand the workflow
     }
 
     async fn coder_client_from_store(store: &SharedStore) -> Option<CoderClient> {
+        let coder_cfg = config::EnvConfig::from_env().ok();
         let coder_url: Option<String> = store
             .get_typed("coder_url")
             .await
-            .or_else(|| std::env::var("CODER_URL").ok());
-        let coder_token: Option<String> = std::env::var("CODER_SESSION_TOKEN")
-            .ok()
+            .or_else(|| coder_cfg.as_ref().map(|e| e.coder.url.clone()));
+        let coder_token: Option<String> = coder_cfg
+            .and_then(|e| e.coder.session_token)
             .or_else(|| std::env::var("CODER_API_TOKEN").ok());
         let coder_token = if coder_token.as_deref().is_some_and(|t| !t.is_empty()) {
             coder_token
@@ -877,8 +896,14 @@ Before significant work, read the relevant skill file to understand the workflow
                 "role": worker_id,
                 "ticket_id": ticket_id,
                 "redis_url": "redis://redis:6379",
-                "tenant": std::env::var("OPENFLOWS_TENANT").unwrap_or_else(|_| "default".to_string()),
-                "coder_url": coder_url.unwrap_or_else(|| std::env::var("CODER_URL").unwrap_or_default()),
+                "tenant": config::EnvConfig::from_env()
+                    .map(|e| e.tenant.effective_tenant().to_string())
+                    .unwrap_or_else(|_| "default".to_string()),
+                "coder_url": coder_url.unwrap_or_else(|| {
+                    config::EnvConfig::from_env()
+                        .map(|e| e.coder.url)
+                        .unwrap_or_default()
+                }),
             }),
         };
         // Inject the Terraform variable the template reads.
@@ -1312,7 +1337,9 @@ Before significant work, read the relevant skill file to understand the workflow
         // when the hook rewrites or overrides initial prompts.
         // The hook's stdout becomes the session context automatically in Claude Code.
         use coder_client::types::{build_chat_labels, CreateChatRequest};
-        let tenant = std::env::var("OPENFLOWS_TENANT").unwrap_or_else(|_| "default".to_string());
+        let tenant = config::EnvConfig::from_env()
+            .map(|e| e.tenant.effective_tenant().to_string())
+            .unwrap_or_else(|_| "default".to_string());
         let labels = build_chat_labels(ticket_id, role, "openflows", &tenant);
 
         // Resolve the default organization ID required by the Coder chats API.
@@ -2444,16 +2471,13 @@ Use `openflows-harness` for all coordination:
 
         let token = match self.resolve_github_token() {
             Ok(t) if !t.is_empty() => t,
-            Ok(_) | Err(_) => match std::env::var("GITHUB_TOKEN") {
-                Ok(t) if !t.is_empty() => t,
-                Ok(_) | Err(_) => match std::fs::read_to_string("/tmp/github_token") {
-                    Ok(t) if !t.trim().is_empty() => t.trim().to_string(),
-                    Ok(_) | Err(_) => {
-                        warn!("GitHub token not configured, assuming CI is ready");
-                        store.set(KEY_CI_READINESS, json!(CiReadiness::Ready)).await;
-                        return CiReadiness::Ready;
-                    }
-                },
+            Ok(_) | Err(_) => match self.resolve_github_token_from_env_or_file() {
+                Some(t) => t,
+                None => {
+                    warn!("GitHub token not configured, assuming CI is ready");
+                    store.set(KEY_CI_READINESS, json!(CiReadiness::Ready)).await;
+                    return CiReadiness::Ready;
+                }
             },
         };
 
@@ -2480,7 +2504,10 @@ Use `openflows-harness` for all coordination:
     /// Checks common workspace locations like ~/Sandbox/{repo_name}
     fn detect_workspace_path(_owner: &str, repo_name: &str) -> std::path::PathBuf {
         // Check for WORKSPACE_ROOT environment variable first
-        if let Ok(workspace_root) = std::env::var("WORKSPACE_ROOT") {
+        if let Some(workspace_root) = config::EnvConfig::from_env()
+            .ok()
+            .and_then(|e| e.agent.effective_workspace_root())
+        {
             let path = std::path::PathBuf::from(workspace_root).join(repo_name);
             if path.exists() {
                 return path;
@@ -2710,7 +2737,7 @@ Use `openflows-harness` for all coordination:
         let worker_entry = registry.get(&base_id);
 
         // Resolve the worker's GitHub token. resolve_github_token() falls back
-        // to GITHUB_PERSONAL_ACCESS_TOKEN when no dedicated github_token_env is
+        // to GITHUB_TOKEN when no dedicated github_token_env is
         // configured on the registry entry, so agents without a per-agent token
         // still work as long as the fallback env var is set. We do NOT hard-fail
         // on a missing github_token_env field — that would block all v2-style
@@ -2726,7 +2753,7 @@ Use `openflows-harness` for all coordination:
             let env_var_name = worker_entry
                 .as_ref()
                 .and_then(|e| e.github_token_env.as_deref())
-                .unwrap_or("GITHUB_PERSONAL_ACCESS_TOKEN");
+                .unwrap_or("GITHUB_TOKEN");
             let comment = format!(
                 "<!-- openflows-assignment-failure -->\n\
                  ⚠️ **Could not assign this issue to `{}`** — the agent's GitHub token could not \
@@ -3751,14 +3778,16 @@ impl Node for NexusNode {
             warn!("Failed to sync registry: {}", e);
         }
 
-        let repository = if let Ok(repo) = std::env::var("GITHUB_REPOSITORY") {
-            repo
-        } else {
-            store
+        let repository = match config::EnvConfig::from_env()
+            .ok()
+            .and_then(|e| e.github.repository)
+        {
+            Some(repo) => repo,
+            None => store
                 .get("repository")
                 .await
                 .and_then(|v| v.as_str().map(String::from))
-                .unwrap_or_default()
+                .unwrap_or_default(),
         };
 
         // Store repository in Redis so workspace provisioning can use it

--- a/crates/agent-sentinel/src/lib.rs
+++ b/crates/agent-sentinel/src/lib.rs
@@ -11,7 +11,7 @@ use config::state::{
     full_ticket_key, full_ticket_key_flat, KEY_TICKETS, KEY_TICKET_CHAT, KEY_TICKET_CHAT_ACTION,
     KEY_TICKET_STATUS, KEY_WORKER_SLOTS,
 };
-use config::{Ticket, TicketStatus, WorkerSlot, WorkerStatus};
+use config::{Envconfig, Ticket, TicketStatus, WorkerSlot, WorkerStatus};
 use pocketflow_core::{node::PAUSE_SIGNAL, Action, Node, SharedStore};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -41,12 +41,13 @@ impl SentinelNode {
     }
 
     async fn coder_client_from_store(store: &SharedStore) -> Option<CoderClient> {
+        let coder = config::CoderConfig::init_from_env().ok();
         let coder_url: Option<String> = store
             .get_typed("coder_url")
             .await
-            .or_else(|| std::env::var("CODER_URL").ok());
-        let coder_token: Option<String> = std::env::var("CODER_SESSION_TOKEN")
-            .ok()
+            .or_else(|| coder.as_ref().map(|c| c.url.clone()));
+        let coder_token: Option<String> = coder
+            .and_then(|c| c.session_token)
             .or_else(|| std::env::var("CODER_API_TOKEN").ok());
         let coder_token = if coder_token.as_deref().is_some_and(|t| !t.is_empty()) {
             coder_token
@@ -177,16 +178,15 @@ impl Node for SentinelNode {
                                     "Sentinel chat still running — waiting for review"
                                 );
                             }
-                            ChatStatus::Waiting => {
+                            ChatStatus::Waiting
                                 if (last_action.as_deref() == Some("completed")
                                     || last_action.is_none())
-                                    && !has_review
-                                {
-                                    info!(
-                                        ticket_id = %ticket.id,
-                                        "Sentinel chat waiting but no review written yet — sending follow-up"
-                                    );
-                                }
+                                    && !has_review =>
+                            {
+                                info!(
+                                    ticket_id = %ticket.id,
+                                    "Sentinel chat waiting but no review written yet — sending follow-up"
+                                );
                             }
                             ChatStatus::Error => {
                                 warn!(

--- a/crates/agent-vessel/src/node.rs
+++ b/crates/agent-vessel/src/node.rs
@@ -10,7 +10,7 @@ use config::{
     state::{
         full_ticket_key_flat, KEY_PENDING_PRS, KEY_TICKETS, KEY_TICKET_DEPLOYMENT, KEY_WORKER_SLOTS,
     },
-    Ticket, TicketStatus, WorkerSlot, WorkerStatus, ACTION_CI_FIX_NEEDED,
+    Envconfig, Ticket, TicketStatus, WorkerSlot, WorkerStatus, ACTION_CI_FIX_NEEDED,
     ACTION_CONFLICTS_DETECTED,
 };
 use openflows_notifier::{NotificationMessage, NotificationService};
@@ -38,10 +38,6 @@ pub struct VesselNode {
     poller: CiPoller,
     merger: PrMerger,
 }
-
-/// Environment variable for the workspace root directory.
-/// Used to locate worktrees for local conflict resolution.
-const ENV_WORKSPACE_ROOT: &str = "AGENTFLOW_WORKSPACE_ROOT";
 
 /// Maximum number of conflict resolution attempts before giving up.
 const MAX_CONFLICT_RESOLUTION_ATTEMPTS: u32 = 3;
@@ -71,17 +67,16 @@ impl VesselNode {
 
     pub fn from_env() -> Self {
         // Search for registry in OPENFLOWS_HOME first, then workspace root, then CWD
-        let openflows_home = std::env::var("OPENFLOWS_HOME")
-            .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
-            .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
-            .unwrap_or_else(|_| ".openflows".to_string());
-        let oh_path = std::path::PathBuf::from(&openflows_home)
+        let oh_path = config::TenantConfig::init_from_env()
+            .map(|tenant| tenant.openflows_home())
+            .unwrap_or_else(|_| std::path::PathBuf::from(".openflows"))
             .join("orchestration")
             .join("agent")
             .join("registry.json");
-        let workspace_root = std::env::var("AGENTFLOW_WORKSPACE_ROOT")
-            .map(std::path::PathBuf::from)
-            .ok();
+        let workspace_root = config::AgentConfig::init_from_env()
+            .ok()
+            .and_then(|agent| agent.effective_workspace_root())
+            .map(std::path::PathBuf::from);
         let ws_path = workspace_root
             .as_ref()
             .map(|p| p.join("orchestration").join("agent").join("registry.json"));
@@ -105,7 +100,7 @@ impl VesselNode {
             Some(ref path) if path.exists() => {
                 info!(registry_path = %path.display(), "VESSEL loading config from registry");
                 VesselConfig::from_registry(path).unwrap_or_else(|e| {
-                    warn!(error = %e, "VESSEL failed to load from registry, falling back to GITHUB_PERSONAL_ACCESS_TOKEN");
+                    warn!(error = %e, "VESSEL failed to load from registry, falling back to GITHUB_TOKEN");
                     VesselConfig::from_env()
                 })
             }
@@ -126,7 +121,9 @@ impl VesselNode {
     }
 
     fn resolve_worktree_path(&self, pr_info: &PrInfo) -> Option<PathBuf> {
-        let workspace_root = std::env::var(ENV_WORKSPACE_ROOT).ok()?;
+        let workspace_root = config::AgentConfig::init_from_env()
+            .ok()
+            .and_then(|agent| agent.effective_workspace_root())?;
         let branch = &pr_info.head_branch;
         let parts: Vec<&str> = branch.splitn(2, '/').collect();
         if parts.len() != 2 {
@@ -151,8 +148,9 @@ impl VesselNode {
 
     async fn coder_client_from_store(store: &SharedStore) -> Option<CoderClient> {
         let coder_url: Option<String> = store.get_typed("coder_url").await;
-        let coder_token: Option<String> = std::env::var("CODER_SESSION_TOKEN")
+        let coder_token: Option<String> = config::CoderConfig::init_from_env()
             .ok()
+            .and_then(|coder| coder.session_token)
             .or_else(|| std::env::var("CODER_API_TOKEN").ok());
         let coder_token = if coder_token.as_deref().is_some_and(|t| !t.is_empty()) {
             coder_token
@@ -1715,7 +1713,10 @@ impl VesselNode {
         conflicted_files: &[String],
         fallback_ticket_id: Option<&str>,
     ) -> bool {
-        let workspace_root = match std::env::var(ENV_WORKSPACE_ROOT).ok() {
+        let workspace_root = match config::AgentConfig::init_from_env()
+            .ok()
+            .and_then(|agent| agent.effective_workspace_root())
+        {
             Some(root) => root,
             None => {
                 warn!("AGENTFLOW_WORKSPACE_ROOT not set — cannot write CONFLICT_RESOLUTION.md");
@@ -2306,7 +2307,10 @@ impl VesselNode {
         reason: &str,
         failure_detail: Option<&github::CiFailureDetail>,
     ) -> bool {
-        let workspace_root = match std::env::var(ENV_WORKSPACE_ROOT).ok() {
+        let workspace_root = match config::AgentConfig::init_from_env()
+            .ok()
+            .and_then(|agent| agent.effective_workspace_root())
+        {
             Some(root) => root,
             None => {
                 warn!("AGENTFLOW_WORKSPACE_ROOT not set — cannot write CI_FIX.md");

--- a/crates/agent-vessel/src/types.rs
+++ b/crates/agent-vessel/src/types.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use config::Envconfig;
 use config::Registry;
 use pocketflow_core::{CiPollConfig, MergeMethod};
 use serde::{Deserialize, Serialize};
@@ -32,8 +33,14 @@ impl VesselConfig {
     }
 
     pub fn from_env() -> Self {
-        let github_token = std::env::var("GITHUB_PERSONAL_ACCESS_TOKEN")
-            .or_else(|_| std::env::var("CODER_GITHUB_TOKEN"))
+        let github_token = config::GithubConfig::init_from_env()
+            .ok()
+            .and_then(|g| g.token)
+            .or_else(|| {
+                config::CoderConfig::init_from_env()
+                    .ok()
+                    .and_then(|c| c.github_token)
+            })
             .unwrap_or_default();
 
         Self {

--- a/crates/coder-client/Cargo.toml
+++ b/crates/coder-client/Cargo.toml
@@ -9,6 +9,8 @@ description = "Client library for the Coder REST API"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = "0.22"
+config = { version = "0.2.0", path = "../config" }
+envconfig = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }

--- a/crates/coder-client/src/bootstrap.rs
+++ b/crates/coder-client/src/bootstrap.rs
@@ -7,6 +7,8 @@
 
 use crate::{CoderClient, CreateWorkspaceRequest};
 use anyhow::Result;
+use config::{CoderConfig, GithubConfig};
+use envconfig::Envconfig;
 use serde_json::json;
 use std::time::Duration;
 use tracing::{info, warn};
@@ -17,10 +19,23 @@ pub struct CoderBootstrapper {
     admin_email: String,
     admin_password: String,
     admin_username: String,
+    /// Configuration loaded once at startup, reused across the bootstrap flow
+    /// instead of re-parsing `std::env::var(...)` per step.
+    env: Option<config::EnvConfig>,
 }
 
 /// Default admin password that meets Coder's security requirements.
 const SECURE_DEFAULT_PASSWORD: &str = "Op3nFl0ws!";
+
+/// Resolve an already-loaded [`config::EnvConfig`], falling back to parsing the
+/// process environment for callers (e.g. [`CoderBootstrapper::new`]) that were
+/// not constructed from the environment.
+fn load_env(env: Option<&config::EnvConfig>) -> Result<config::EnvConfig> {
+    match env {
+        Some(env) => Ok(env.clone()),
+        None => config::EnvConfig::from_env(),
+    }
+}
 
 /// Check whether a password meets Coder's minimum security requirements.
 ///
@@ -50,14 +65,11 @@ impl CoderBootstrapper {
     /// (uppercase, lowercase, digit, special character, min 8 chars), it is
     /// replaced with the secure default and a warning is logged.
     pub fn from_env() -> Result<Self> {
-        let url =
-            std::env::var("CODER_URL").unwrap_or_else(|_| "http://localhost:7080".to_string());
-        let email = std::env::var("CODER_ADMIN_EMAIL")
-            .unwrap_or_else(|_| "admin@openflows.dev".to_string());
-        let raw_password = std::env::var("CODER_ADMIN_PASSWORD")
-            .unwrap_or_else(|_| SECURE_DEFAULT_PASSWORD.to_string());
-        let username =
-            std::env::var("CODER_ADMIN_USERNAME").unwrap_or_else(|_| "admin".to_string());
+        let env = config::EnvConfig::from_env()?;
+        let url = env.coder.url.clone();
+        let email = env.coder.admin_email.clone();
+        let raw_password = env.coder.admin_password.clone().unwrap_or_default();
+        let username = env.coder.admin_username.clone();
 
         let password = if password_meets_coder_requirements(&raw_password) {
             raw_password
@@ -77,6 +89,7 @@ impl CoderBootstrapper {
             admin_email: email,
             admin_password: password,
             admin_username: username,
+            env: Some(env),
         })
     }
 
@@ -88,6 +101,7 @@ impl CoderBootstrapper {
             admin_email: email.to_string(),
             admin_password: password.to_string(),
             admin_username: username.to_string(),
+            env: None,
         }
     }
 
@@ -108,26 +122,33 @@ impl CoderBootstrapper {
         //     operate as that user instead of creating/logging in as admin.
         //     This lets the system run under any pre-existing Coder user
         //     (e.g. a GitHub-authenticated user) rather than hardcoding admin.
-        if let Ok(existing_token) = std::env::var("CODER_SESSION_TOKEN") {
-            if !existing_token.is_empty() {
-                let probe_client = self
-                    .client
-                    .with_token(existing_token.clone())
+        let existing_token = self
+            .env
+            .as_ref()
+            .and_then(|e| e.coder.session_token.clone())
+            .or_else(|| {
+                CoderConfig::init_from_env()
+                    .ok()
+                    .and_then(|c| c.session_token)
+            });
+        if let Some(existing_token) = existing_token.filter(|t| !t.is_empty()) {
+            let probe_client = self
+                .client
+                .with_token(existing_token.clone())
+                .with_session_token(&existing_token);
+            if let Ok(me) = probe_client.get_me().await {
+                info!(
+                    username = %me.username,
+                    user_id = %me.id,
+                    "  ✓ Reusing existing CODER_SESSION_TOKEN for user '{}' — skipping admin bootstrap",
+                    me.username
+                );
+                let api_key = probe_client.create_api_token(&me.id, "openflows").await?;
+                let client = probe_client
+                    .with_token(api_key.key.clone())
                     .with_session_token(&existing_token);
-                if let Ok(me) = probe_client.get_me().await {
-                    info!(
-                        username = %me.username,
-                        user_id = %me.id,
-                        "  ✓ Reusing existing CODER_SESSION_TOKEN for user '{}' — skipping admin bootstrap",
-                        me.username
-                    );
-                    let api_key = probe_client.create_api_token(&me.id, "openflows").await?;
-                    let client = probe_client
-                        .with_token(api_key.key.clone())
-                        .with_session_token(&existing_token);
-                    info!("  ✓ API token generated for '{}'", me.username);
-                    return Self::push_templates_and_create_nexus(client).await;
-                }
+                info!("  ✓ API token generated for '{}'", me.username);
+                return Self::push_templates_and_create_nexus(client, self.env.as_ref()).await;
             }
         }
 
@@ -186,13 +207,16 @@ impl CoderBootstrapper {
             .with_session_token(&session_token);
         info!("  ✓ API token generated");
 
-        Self::push_templates_and_create_nexus(client).await
+        Self::push_templates_and_create_nexus(client, self.env.as_ref()).await
     }
 
     /// Shared post-auth logic: push templates and create the nexus workspace.
     /// Used by both the "reuse existing token" fast path and the full admin
     /// bootstrap path.
-    async fn push_templates_and_create_nexus(client: CoderClient) -> Result<CoderClient> {
+    async fn push_templates_and_create_nexus(
+        client: CoderClient,
+        env: Option<&config::EnvConfig>,
+    ) -> Result<CoderClient> {
         let resolved_user = client.resolve_current_user().await?;
         info!(
             username = %resolved_user,
@@ -208,10 +232,9 @@ impl CoderBootstrapper {
         // Check whether nexus workspace creation is enabled before deleting
         // any stale workspace. If creation is disabled, we must preserve the
         // existing one.
-        let create_nexus_workspace = std::env::var("OPENFLOWS_CREATE_NEXUS_WORKSPACE")
-            .map(|v| v != "false")
-            .unwrap_or(true)
-            && std::env::var("ROLE").as_deref() != Ok("nexus");
+        let env_cfg = load_env(env)?;
+        let create_nexus_workspace = env_cfg.agent.create_nexus_workspace_enabled()
+            && env_cfg.agent.role.as_deref() != Some("nexus");
 
         // Track template push failures — bootstrap must fail if required
         // templates cannot be pushed, so the caller knows provisioning is
@@ -287,7 +310,7 @@ impl CoderBootstrapper {
         // OPENFLOWS_CREATE_NEXUS_WORKSPACE=false or ROLE=nexus, preserving
         // the existing control plane avoids a window with no workspace.
         if nexus_template_updated && create_nexus_workspace {
-            Self::delete_stale_nexus_workspace(&client).await?;
+            Self::delete_stale_nexus_workspace(&client, env).await?;
         }
 
         // Create or refresh the long-lived Nexus workspace outside Coder.
@@ -295,7 +318,7 @@ impl CoderBootstrapper {
         // This is the bootstrapper's "first mover" responsibility: seed the
         // persistent control-plane workspace that runs the orchestration loop.
         if create_nexus_workspace {
-            Self::create_nexus_workspace(&client).await?;
+            Self::create_nexus_workspace(&client, env).await?;
         }
 
         info!("  ✓ Coder bootstrapped");
@@ -329,9 +352,15 @@ impl CoderBootstrapper {
     /// Returns Ok if no workspace existed, or after successful deletion.
     /// Returns Err if deletion failed — callers must fail bootstrap to avoid
     /// a name conflict when recreating the workspace.
-    async fn delete_stale_nexus_workspace(client: &CoderClient) -> Result<()> {
-        let nexus_workspace_name = std::env::var("OPENFLOWS_NEXUS_WORKSPACE_NAME")
-            .unwrap_or_else(|_| "openflows-nexus".to_string());
+    async fn delete_stale_nexus_workspace(
+        client: &CoderClient,
+        env: Option<&config::EnvConfig>,
+    ) -> Result<()> {
+        let env_cfg = load_env(env)?;
+        let nexus_workspace_name = env_cfg
+            .tenant
+            .nexus_workspace_name
+            .unwrap_or_else(|| "openflows-nexus".to_string());
         let me = client.get_me().await.map_err(|e| {
             anyhow::anyhow!(
                 "Failed to resolve current user while checking for stale nexus workspace '{}': {}. \
@@ -428,30 +457,42 @@ impl CoderBootstrapper {
     /// Returns Err if the workspace could not be created or did not become
     /// ready. Callers must fail bootstrap on error so a deleted control plane
     /// is never left without a functional replacement.
-    async fn create_nexus_workspace(client: &CoderClient) -> Result<()> {
-        let nexus_workspace_name = std::env::var("OPENFLOWS_NEXUS_WORKSPACE_NAME")
-            .unwrap_or_else(|_| "openflows-nexus".to_string());
-        let nexus_api_token = std::env::var("OPENFLOWS_NEXUS_API_TOKEN")
-            .or_else(|_| std::env::var("NEXUS_CODER_API_TOKEN"))
-            .unwrap_or_else(|_| client.token().to_string());
-        let repository = std::env::var("GITHUB_REPOSITORY").unwrap_or_else(|_| String::new());
+    async fn create_nexus_workspace(
+        client: &CoderClient,
+        env: Option<&config::EnvConfig>,
+    ) -> Result<()> {
+        let env_cfg = load_env(env)?;
+        let tenant_cfg = &env_cfg.tenant;
+        let github_cfg = &env_cfg.github;
+        let nexus_workspace_name = tenant_cfg
+            .nexus_workspace_name
+            .clone()
+            .unwrap_or_else(|| "openflows-nexus".to_string());
+        let nexus_api_token = tenant_cfg
+            .nexus_api_token
+            .clone()
+            .or_else(|| std::env::var("NEXUS_CODER_API_TOKEN").ok())
+            .unwrap_or_else(|| client.token().to_string());
+        let repository = github_cfg.repository.clone().unwrap_or_default();
         let repo_url = if repository.is_empty() {
             String::new()
         } else {
             format!("https://github.com/{}.git", repository)
         };
         let redis_url = "redis://redis:6379".to_string();
-        let tenant = std::env::var("OPENFLOWS_TENANT").unwrap_or_else(|_| "default".to_string());
-        let registry_json = match std::env::var("OPENFLOWS_REGISTRY_JSON") {
-            Ok(json) => json,
-            Err(_) => {
-                let path = std::env::var("OPENFLOWS_REGISTRY_PATH")
-                    .unwrap_or_else(|_| "orchestration/agent/registry.json".to_string());
+        let tenant = tenant_cfg.effective_tenant().to_string();
+        let registry_json = match tenant_cfg.registry_json.clone() {
+            Some(json) => json,
+            None => {
+                let path = tenant_cfg
+                    .registry_path
+                    .clone()
+                    .unwrap_or_else(|| "orchestration/agent/registry.json".to_string());
                 std::fs::read_to_string(&path).unwrap_or_default()
             }
         };
         let coder_url_for_workspace = client.base_url().replace("localhost", "coder");
-        let github_pat = std::env::var("GITHUB_PERSONAL_ACCESS_TOKEN").unwrap_or_default();
+        let github_pat = github_cfg.token.clone().unwrap_or_default();
 
         let workspace = client
             .create_workspace(&CreateWorkspaceRequest {
@@ -545,16 +586,16 @@ impl CoderBootstrapper {
             }
             Err(e) => {
                 warn!(error = %e, "Could not verify LLM configuration (Chats API may not be enabled yet)");
-                info!("  ⚠ Could not verify LLM config — ensure at least one model is configured in the Coder dashboard");
+                info!("  ⚠ Could not verify LLM config — ensure Coder Agents/AI is enabled and at least one model is configured (dashboard → AI Settings → Coder Agents → Models)");
                 Ok(())
             }
         }
     }
 
     /// Verify that GitHub external auth is configured on the Coder server.
-    /// This is now a no-op since GitHub OAuth is configured directly in the Coder dashboard.
+    ///  needed for agents authentication
     pub fn verify_external_auth_configured() -> Result<()> {
-        info!("  ✓ GitHub external auth should be configured in the Coder dashboard");
+        info!("  ✓ GitHub external auth configure in the Coder dashboard if agents authentication");
         Ok(())
     }
 
@@ -713,7 +754,12 @@ impl CoderBootstrapper {
         let nexus_workspace_name = format!("openflows-nexus-{}", tenant_name);
         let repo_url = format!("https://github.com/{}.git", github_repo);
 
-        let github_pat = std::env::var("GITHUB_PERSONAL_ACCESS_TOKEN").unwrap_or_default();
+        let github_pat = self
+            .env
+            .as_ref()
+            .and_then(|e| e.github.token.clone())
+            .or_else(|| GithubConfig::init_from_env().ok().and_then(|c| c.token))
+            .unwrap_or_default();
         let workspace = client
             .create_workspace_for_user(
                 &tenant_user.id,

--- a/crates/coder-client/src/chat_stream.rs
+++ b/crates/coder-client/src/chat_stream.rs
@@ -103,14 +103,7 @@ impl ChatStream {
     pub async fn connect(coder_url: &str, token: &str, chat_id: &str) -> Result<Self> {
         use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 
-        let ws_url = if coder_url.starts_with("ws") {
-            format!("{}/api/experimental/chats/{}/events", coder_url, chat_id)
-        } else {
-            coder_url
-                .replace("http://", "ws://")
-                .replace("https://", "wss://")
-                + &format!("/api/experimental/chats/{}/events", chat_id)
-        };
+        let ws_url = Self::stream_url(coder_url, chat_id);
 
         debug!(url = %ws_url, chat_id, "Connecting to chat WebSocket stream");
 
@@ -140,6 +133,25 @@ impl ChatStream {
             chat_id: chat_id.to_string(),
             finished: false,
         })
+    }
+
+    /// Build the v2 WebSocket stream URL for a chat session.
+    ///
+    /// Points at Coder's `/api/v2/chats/{chat_id}/stream` endpoint. An
+    /// `http(s)://` base URL is translated to `ws(s)://`; a `ws(s)://` base
+    /// URL is used as-is.
+    fn stream_url(coder_url: &str, chat_id: &str) -> String {
+        let path = format!("/api/v2/chats/{}/stream", chat_id);
+        if coder_url.starts_with("ws") {
+            format!("{}{}", coder_url.trim_end_matches('/'), path)
+        } else {
+            coder_url
+                .replace("http://", "ws://")
+                .replace("https://", "wss://")
+                .trim_end_matches('/')
+                .to_string()
+                + &path
+        }
     }
 
     /// The chat ID this stream is reading from.
@@ -269,5 +281,59 @@ mod tests {
             ChatEvent::StatusUpdate { status } => assert_eq!(status, "running"),
             other => panic!("Expected StatusUpdate, got: {:?}", other),
         }
+    }
+
+    #[test]
+    fn stream_url_uses_v2_path_for_ws_prefixed_base() {
+        let url = ChatStream::stream_url("ws://127.0.0.1:4321", "chat-123");
+        assert_eq!(url, "ws://127.0.0.1:4321/api/v2/chats/chat-123/stream");
+    }
+
+    #[test]
+    fn stream_url_translates_http_to_ws() {
+        let url = ChatStream::stream_url("http://localhost:3000", "chat-123");
+        assert_eq!(url, "ws://localhost:3000/api/v2/chats/chat-123/stream");
+    }
+
+    #[test]
+    fn stream_url_translates_https_to_wss() {
+        let url = ChatStream::stream_url("https://coder.example.com", "chat-9");
+        assert_eq!(url, "wss://coder.example.com/api/v2/chats/chat-9/stream");
+    }
+
+    #[test]
+    fn stream_url_handles_trailing_slash() {
+        let url = ChatStream::stream_url("http://localhost:3000/", "chat-1");
+        assert_eq!(url, "ws://localhost:3000/api/v2/chats/chat-1/stream");
+    }
+
+    #[tokio::test]
+    async fn connect_reaches_v2_stream_endpoint_on_mock_server() {
+        use futures::StreamExt;
+
+        let server = crate::mock_chat_server::test_helpers::create_typical_mock().await;
+        let url = server.ws_url();
+        let mut stream = ChatStream::connect(&url, "test-token", "chat-123")
+            .await
+            .expect("connect should succeed against mock server");
+
+        assert_eq!(stream.chat_id(), "chat-123");
+
+        let events: Vec<_> = stream.by_ref().collect().await;
+        assert!(!events.is_empty(), "expected events from mock stream");
+        for event in &events {
+            let event = event.as_ref().expect("stream item should be Ok");
+            assert!(
+                matches!(
+                    event,
+                    ChatEvent::StatusUpdate { .. }
+                        | ChatEvent::Text { .. }
+                        | ChatEvent::Finished { .. }
+                ),
+                "unexpected event {:?}",
+                event
+            );
+        }
+        server.shutdown().await;
     }
 }

--- a/crates/coder-client/src/lib.rs
+++ b/crates/coder-client/src/lib.rs
@@ -25,6 +25,8 @@ pub mod mock_chat_server;
 pub use types::*;
 
 use anyhow::{bail, Context, Result};
+use config::{GithubConfig, TenantConfig};
+use envconfig::Envconfig;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -1533,8 +1535,9 @@ impl CoderClient {
 
         // Build naming convention: {role}-{ticket_id} — ticket_id already includes "T-" prefix
         let workspace_name = format!("{}-{}", role, ticket_id);
-        let repository: String =
-            std::env::var("GITHUB_REPOSITORY").unwrap_or_else(|_| "openflows/target".to_string());
+        let repository: String = GithubConfig::init_from_env()?
+            .repository
+            .unwrap_or_else(|| "openflows/target".to_string());
         let repo_url = format!("https://github.com/{}.git", repository);
         let template_name = format!("openflows-{}", role);
 
@@ -1576,7 +1579,9 @@ impl CoderClient {
         let model_config_id = None;
 
         // Create chat with OpenFlows labels (includes tenant)
-        let tenant = std::env::var("OPENFLOWS_TENANT").unwrap_or_else(|_| "default".to_string());
+        let tenant = TenantConfig::init_from_env()?
+            .effective_tenant()
+            .to_string();
         let labels = build_chat_labels(ticket_id, role, "openflows", &tenant);
         let chat_req = CreateChatRequest {
             organization_id,

--- a/crates/coder-client/src/lib.rs
+++ b/crates/coder-client/src/lib.rs
@@ -63,7 +63,7 @@ pub struct CoderClient {
     cached_username: Arc<RwLock<Option<String>>>,
 }
 
-/// Parse the JSON body returned by `GET /api/experimental/chats/models`.
+/// Parse the JSON body returned by `GET /api/v2/organizations/{org}/chats/models`.
 ///
 /// Coder nests models under a top-level `providers` array:
 /// `{"providers":[{"provider":"openai-compat","models":[
@@ -1227,13 +1227,13 @@ impl CoderClient {
     }
 
     /// Create a new Chat session bound to a workspace.
-    /// POST /api/experimental/chats
+    /// POST /api/v2/chats
     pub async fn create_chat(
         &self,
         req: &crate::types::CreateChatRequest,
     ) -> Result<crate::types::Chat> {
         let resp = self
-            .authenticated_request(reqwest::Method::POST, "/api/experimental/chats")
+            .authenticated_request(reqwest::Method::POST, "/api/v2/chats")
             .json(req)
             .send()
             .await
@@ -1251,7 +1251,7 @@ impl CoderClient {
     }
 
     /// Get a Chat by ID.
-    /// GET /api/experimental/chats/{chat}
+    /// GET /api/v2/chats/{chat}
     ///
     /// Returns `Err` for transient failures (timeouts, rate limits, 5xx,
     /// network errors). Callers that need to distinguish "the chat no longer
@@ -1262,10 +1262,7 @@ impl CoderClient {
     /// [`get_chat_opt`]: CoderClient::get_chat_opt
     pub async fn get_chat(&self, chat_id: &str) -> Result<crate::types::Chat> {
         let resp = self
-            .authenticated_request(
-                reqwest::Method::GET,
-                &format!("/api/experimental/chats/{}", chat_id),
-            )
+            .authenticated_request(reqwest::Method::GET, &format!("/api/v2/chats/{}", chat_id))
             .send()
             .await
             .context("Failed to get chat")?;
@@ -1289,10 +1286,7 @@ impl CoderClient {
     /// [`get_chat`]: CoderClient::get_chat
     pub async fn get_chat_opt(&self, chat_id: &str) -> Result<Option<crate::types::Chat>> {
         let resp = self
-            .authenticated_request(
-                reqwest::Method::GET,
-                &format!("/api/experimental/chats/{}", chat_id),
-            )
+            .authenticated_request(reqwest::Method::GET, &format!("/api/v2/chats/{}", chat_id))
             .send()
             .await
             .context("Failed to get chat")?;
@@ -1309,10 +1303,10 @@ impl CoderClient {
     }
 
     /// List all Chats for the current user.
-    /// GET /api/experimental/chats
+    /// GET /api/v2/chats
     pub async fn list_chats(&self) -> Result<Vec<crate::types::Chat>> {
         let resp = self
-            .authenticated_request(reqwest::Method::GET, "/api/experimental/chats")
+            .authenticated_request(reqwest::Method::GET, "/api/v2/chats")
             .send()
             .await
             .context("Failed to list chats")?;
@@ -1337,7 +1331,7 @@ impl CoderClient {
     }
 
     /// Send a message to an existing Chat.
-    /// POST /api/experimental/chats/{chat_id}/messages
+    /// POST /api/v2/chats/{chat_id}/messages
     pub async fn send_chat_message(
         &self,
         chat_id: &str,
@@ -1346,7 +1340,7 @@ impl CoderClient {
         let resp = self
             .authenticated_request(
                 reqwest::Method::POST,
-                &format!("/api/experimental/chats/{}/messages", chat_id),
+                &format!("/api/v2/chats/{}/messages", chat_id),
             )
             .json(&serde_json::json!({
                 "content": content,
@@ -1367,7 +1361,7 @@ impl CoderClient {
     }
 
     /// Get recent messages from a Chat.
-    /// GET /api/experimental/chats/{chat_id}/messages?after_id={id}&limit={n}
+    /// GET /api/v2/chats/{chat_id}/messages?after_id={id}&limit={n}
     pub async fn get_chat_messages(
         &self,
         chat_id: &str,
@@ -1376,10 +1370,7 @@ impl CoderClient {
         let resp = self
             .authenticated_request(
                 reqwest::Method::GET,
-                &format!(
-                    "/api/experimental/chats/{}/messages?limit={}",
-                    chat_id, limit
-                ),
+                &format!("/api/v2/chats/{}/messages?limit={}", chat_id, limit),
             )
             .send()
             .await
@@ -1405,12 +1396,12 @@ impl CoderClient {
     }
 
     /// Archive a Chat (soft delete).
-    /// PATCH /api/experimental/chats/{chat_id}
+    /// PATCH /api/v2/chats/{chat_id}
     pub async fn archive_chat(&self, chat_id: &str) -> Result<()> {
         let resp = self
             .authenticated_request(
                 reqwest::Method::PATCH,
-                &format!("/api/experimental/chats/{}", chat_id),
+                &format!("/api/v2/chats/{}", chat_id),
             )
             .json(&serde_json::json!({ "archived": true }))
             .send()
@@ -1428,12 +1419,12 @@ impl CoderClient {
     }
 
     /// Interrupt a running Chat.
-    /// POST /api/experimental/chats/{chat_id}/interrupt
+    /// POST /api/v2/chats/{chat_id}/interrupt
     pub async fn interrupt_chat(&self, chat_id: &str) -> Result<()> {
         let resp = self
             .authenticated_request(
                 reqwest::Method::POST,
-                &format!("/api/experimental/chats/{}/interrupt", chat_id),
+                &format!("/api/v2/chats/{}/interrupt", chat_id),
             )
             .send()
             .await
@@ -1450,7 +1441,10 @@ impl CoderClient {
     }
 
     /// List available models for chats.
-    /// GET /api/experimental/chats/models
+    /// GET /api/v2/organizations/{organization}/chats/models
+    ///
+    /// Models are organization-scoped in Coder v2.37+; the default organization
+    /// is resolved via [`CoderClient::get_default_organization_id`].
     ///
     /// Uses an internal cache (5-minute TTL) to reduce API calls.
     /// Call `invalidate_cache()` to force a refresh.
@@ -1465,9 +1459,15 @@ impl CoderClient {
             }
         }
 
+        // Models are organization-scoped in Coder v2.37+.
+        let organization_id = self.get_default_organization_id().await?;
+
         // Fetch from API
         let resp = self
-            .authenticated_request(reqwest::Method::GET, "/api/experimental/chats/models")
+            .authenticated_request(
+                reqwest::Method::GET,
+                &format!("/api/v2/organizations/{}/chats/models", organization_id),
+            )
             .send()
             .await
             .context("Failed to list chat models")?;
@@ -1489,11 +1489,17 @@ impl CoderClient {
     }
 
     /// List available models for chats without caching.
-    /// GET /api/experimental/chats/models
+    /// GET /api/v2/organizations/{organization}/chats/models
     #[cfg(not(feature = "chats-api"))]
     pub async fn list_chat_models(&self) -> Result<Vec<crate::types::ModelInfo>> {
+        // Models are organization-scoped in Coder v2.37+.
+        let organization_id = self.get_default_organization_id().await?;
+
         let resp = self
-            .authenticated_request(reqwest::Method::GET, "/api/experimental/chats/models")
+            .authenticated_request(
+                reqwest::Method::GET,
+                &format!("/api/v2/organizations/{}/chats/models", organization_id),
+            )
             .send()
             .await
             .context("Failed to list chat models")?;
@@ -1541,6 +1547,15 @@ impl CoderClient {
         let repo_url = format!("https://github.com/{}.git", repository);
         let template_name = format!("openflows-{}", role);
 
+        // Resolve the default organization ID BEFORE provisioning the workspace.
+        // In the Coder v2 GA Chats API the organization_id is REQUIRED — the caller
+        // must be a member of the org the chat belongs to. Failing fast here avoids
+        // consuming workspace resources (create/start/await) when the org cannot be
+        // resolved, since the chat could never be created without it.
+        let organization_id = self.get_default_organization_id().await.context(
+            "Failed to resolve default organization ID (required by the Coder v2 Chats API)",
+        )?;
+
         // Create (or find existing) workspace
         info!(
             workspace_name,
@@ -1562,18 +1577,6 @@ impl CoderClient {
         self.wait_for_workspace_ssh(&workspace.id, std::time::Duration::from_secs(120))
             .await?;
 
-        // Resolve the default organization ID required by the Coder chats API.
-        let organization_id = match self.get_default_organization_id().await {
-            Ok(id) => Some(id),
-            Err(e) => {
-                warn!(
-                    error = %e,
-                    "Failed to resolve default organization ID; chat creation may fail"
-                );
-                None
-            }
-        };
-
         // Let Coder use the workspace's default model.
         // model_config_id expects a UUID, not a model name, so we pass None.
         let model_config_id = None;
@@ -1584,7 +1587,7 @@ impl CoderClient {
             .to_string();
         let labels = build_chat_labels(ticket_id, role, "openflows", &tenant);
         let chat_req = CreateChatRequest {
-            organization_id,
+            organization_id: Some(organization_id),
             workspace_id: workspace.id.clone(),
             model_config_id,
             content: vec![ChatInputPart::text(prompt)],
@@ -1721,6 +1724,160 @@ fn canonicalize_host_path(p: &str) -> String {
 }
 
 #[cfg(test)]
+mod http_mock {
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio::sync::Mutex;
+
+    /// A minimal in-process HTTP/1.1 server for exercising the Coder client
+    /// against mocked `/api/v2` routes without a real Coder deployment.
+    pub struct HttpMock {
+        addr: SocketAddr,
+        requests: Arc<Mutex<Vec<RecordedRequest>>>,
+        handle: Option<tokio::task::JoinHandle<()>>,
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct RecordedRequest {
+        pub method: String,
+        pub path: String,
+        pub body: String,
+    }
+
+    impl HttpMock {
+        pub async fn new() -> anyhow::Result<Self> {
+            let listener = TcpListener::bind("127.0.0.1:0").await?;
+            let addr = listener.local_addr()?;
+            let requests = Arc::new(Mutex::new(Vec::new()));
+            let handle = tokio::spawn(Self::run(listener, Arc::clone(&requests)));
+            Ok(Self {
+                addr,
+                requests,
+                handle: Some(handle),
+            })
+        }
+
+        pub fn url(&self) -> String {
+            format!("http://{}", self.addr)
+        }
+
+        pub async fn requests(&self) -> Vec<RecordedRequest> {
+            self.requests.lock().await.clone()
+        }
+
+        pub async fn shutdown(self) {
+            if let Some(handle) = self.handle {
+                handle.abort();
+                let _ = handle.await;
+            }
+        }
+
+        async fn run(listener: TcpListener, requests: Arc<Mutex<Vec<RecordedRequest>>>) {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let requests = Arc::clone(&requests);
+                tokio::spawn(async move {
+                    let _ = Self::handle_conn(stream, requests).await;
+                });
+            }
+        }
+
+        async fn handle_conn(
+            mut stream: TcpStream,
+            requests: Arc<Mutex<Vec<RecordedRequest>>>,
+        ) -> std::io::Result<()> {
+            let mut buf: Vec<u8> = Vec::with_capacity(4096);
+            loop {
+                // Read until a full header terminator is in the buffer.
+                let header_end = loop {
+                    if let Some(pos) = find_subsequence(&buf, b"\r\n\r\n") {
+                        break pos + 4;
+                    }
+                    let mut chunk = [0u8; 512];
+                    let n = stream.read(&mut chunk).await?;
+                    if n == 0 {
+                        return Ok(());
+                    }
+                    buf.extend_from_slice(&chunk[..n]);
+                };
+
+                let head = String::from_utf8_lossy(&buf[..header_end]);
+                let mut lines = head.lines();
+                let mut req_parts = lines.next().unwrap_or("").split_whitespace();
+                let method = req_parts.next().unwrap_or("").to_string();
+                let path = req_parts.next().unwrap_or("").to_string();
+                let mut content_length = 0usize;
+                for line in lines {
+                    let lower = line.to_ascii_lowercase();
+                    if let Some(v) = lower.strip_prefix("content-length:") {
+                        content_length = v.trim().parse().unwrap_or(0);
+                    }
+                }
+
+                while buf.len() < header_end + content_length {
+                    let mut chunk = [0u8; 512];
+                    let n = stream.read(&mut chunk).await?;
+                    if n == 0 {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::UnexpectedEof,
+                            "unexpected EOF while reading body",
+                        ));
+                    }
+                    buf.extend_from_slice(&chunk[..n]);
+                }
+
+                let body = String::from_utf8_lossy(&buf[header_end..header_end + content_length])
+                    .to_string();
+                requests.lock().await.push(RecordedRequest {
+                    method: method.clone(),
+                    path: path.clone(),
+                    body,
+                });
+
+                let (status, content) = route(&method, &path);
+                let response = format!(
+                    "HTTP/1.1 {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: keep-alive\r\n\r\n{}",
+                    status,
+                    content.len(),
+                    content
+                );
+                stream.write_all(response.as_bytes()).await?;
+                stream.flush().await?;
+
+                buf.drain(..header_end + content_length);
+            }
+        }
+    }
+
+    fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+        haystack.windows(needle.len()).position(|w| w == needle)
+    }
+
+    fn route(method: &str, path: &str) -> (&'static str, String) {
+        match (method, path) {
+            ("GET", "/api/v2/organizations") => (
+                "200 OK",
+                r#"[{"id":"org-abc","name":"default","is_default":true}]"#.to_string(),
+            ),
+            ("GET", "/api/v2/organizations/org-abc/chats/models") => (
+                "200 OK",
+                r#"{"providers":[{"provider":"openai-compat","available":true,"models":[{"id":"openai-compat:reviewer-pro","provider":"openai-compat","model":"reviewer-pro","display_name":"Reviewer Pro"}]}]}"#
+                    .to_string(),
+            ),
+            ("POST", "/api/v2/chats") => (
+                "201 Created",
+                r#"{"id":"chat-1","organization_id":"org-abc"}"#.to_string(),
+            ),
+            _ => ("404 Not Found", r#"{"message":"not found"}"#.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::parse_chat_models_body;
 
@@ -1800,5 +1957,74 @@ mod tests {
         let models = parse_chat_models_body(&body);
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, "x");
+    }
+
+    #[tokio::test]
+    async fn list_chat_models_resolves_default_org_and_hits_org_scoped_path() {
+        let server = super::http_mock::HttpMock::new().await.unwrap();
+        let client = crate::CoderClient::new(&server.url(), "test-token");
+
+        let models = client
+            .list_chat_models()
+            .await
+            .expect("list_chat_models should succeed against mock");
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "reviewer-pro");
+        assert_eq!(models[0].provider, "openai-compat");
+
+        let requests = server.requests().await;
+        let orgs_hit = requests
+            .iter()
+            .any(|r| r.method == "GET" && r.path == "/api/v2/organizations");
+        assert!(
+            orgs_hit,
+            "expected org resolution to hit /api/v2/organizations"
+        );
+        let models_hit = requests
+            .iter()
+            .any(|r| r.method == "GET" && r.path == "/api/v2/organizations/org-abc/chats/models");
+        assert!(
+            models_hit,
+            "expected models fetch to hit /api/v2/organizations/'{{org}}'/chats/models"
+        );
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn create_chat_sends_required_non_empty_organization_id() {
+        use crate::types::CreateChatRequest;
+
+        let server = super::http_mock::HttpMock::new().await.unwrap();
+        let client = crate::CoderClient::new(&server.url(), "test-token");
+
+        let req = CreateChatRequest {
+            organization_id: Some("org-abc".to_string()),
+            workspace_id: "ws-1".to_string(),
+            model_config_id: None,
+            content: vec![crate::types::ChatInputPart::text("hello")],
+            labels: None,
+        };
+        let chat = client
+            .create_chat(&req)
+            .await
+            .expect("create_chat should succeed against mock");
+        assert_eq!(chat.id, "chat-1");
+
+        let requests = server.requests().await;
+        let create = requests
+            .iter()
+            .find(|r| r.method == "POST" && r.path == "/api/v2/chats")
+            .expect("expected a POST /api/v2/chats request");
+
+        let body: serde_json::Value =
+            serde_json::from_str(&create.body).expect("recorded body should be valid JSON");
+        let org_id = body
+            .get("organization_id")
+            .and_then(|v| v.as_str())
+            .expect("organization_id must be present and a string");
+        assert!(!org_id.is_empty(), "organization_id must not be empty");
+        assert_eq!(org_id, "org-abc");
+        server.shutdown().await;
     }
 }

--- a/crates/coder-client/src/mock_chat_server.rs
+++ b/crates/coder-client/src/mock_chat_server.rs
@@ -1,14 +1,14 @@
 // crates/coder-client/src/mock_chat_server.rs
 //! Mock WebSocket chat server for testing the ChatStream implementation.
 //!
-//! Provides a lightweight server that mimics Coder's `/api/experimental/chats/{id}/events`
+//! Provides a lightweight server that mimics Coder's `/api/v2/chats/{id}/stream`
 //! WebSocket endpoint, emitting predetermined events for testing.
 
 use futures_util::{SinkExt, StreamExt};
 use serde_json::json;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::net::TcpListener;
+use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::Mutex;
 use tokio_tungstenite::tungstenite::Message;
 use tracing::{info, warn};
@@ -62,6 +62,14 @@ impl MockChatServer {
         format!("ws://{}", self.addr)
     }
 
+    /// Get the full v2 stream endpoint for a chat session.
+    ///
+    /// Mimics Coder's `/api/v2/chats/{id}/stream` WebSocket route so tests
+    /// exercise the same path the client connects to.
+    pub fn v2_stream_url(&self, chat_id: &str) -> String {
+        format!("{}/api/v2/chats/{}/stream", self.ws_url(), chat_id)
+    }
+
     /// Get just the host:port part (e.g., "127.0.0.1:8080").
     pub fn addr_str(&self) -> String {
         self.addr.to_string()
@@ -95,7 +103,13 @@ impl MockChatServer {
                     info!(peer = %peer_addr, "Mock chat server: new WS connection");
                     let events_clone = Arc::clone(&events);
                     tokio::spawn(async move {
-                        if let Ok(ws_stream) = tokio_tungstenite::accept_async(stream).await {
+                        // Echo the requested subprotocol so the client's
+                        // `Sec-WebSocket-Protocol: chat-stream-v1` handshake
+                        // succeeds (the real Coder server negotiates it too),
+                        // and reject connections to any non-stream route so the
+                        // mock independently verifies the client's target URL.
+                        if let Ok(ws_stream) = accept_v2_stream_handshake(stream).await
+                        {
                             let (mut _ws_sink, _ws_stream) = ws_stream.split();
 
                             // Emit events to the client sequentially
@@ -135,6 +149,51 @@ impl MockChatServer {
     }
 }
 
+/// Accept a WebSocket connection for the mock chat server, but only when the
+/// client is connecting to the Coder v2 chat stream route
+/// `/api/v2/chats/{chat_id}/stream`. Any other URI is rejected so the mock
+/// independently verifies the client's target endpoint rather than accepting
+/// every path.
+///
+/// The handshake callback's `Err` variant is inherently large (tungstenite's
+/// `Error` type), so `result_large_err` is suppressed here.
+#[allow(clippy::result_large_err)]
+async fn accept_v2_stream_handshake(
+    stream: TcpStream,
+) -> Result<
+    tokio_tungstenite::WebSocketStream<TcpStream>,
+    tokio_tungstenite::tungstenite::error::Error,
+> {
+    tokio_tungstenite::accept_hdr_async(
+        stream,
+        |req: &tokio_tungstenite::tungstenite::handshake::server::Request,
+         mut resp: tokio_tungstenite::tungstenite::handshake::server::Response| {
+            let path = req.uri().path();
+            let is_v2_stream = path.starts_with("/api/v2/chats/") && path.ends_with("/stream");
+            if !is_v2_stream {
+                warn!(
+                    uri = %req.uri(),
+                    "Mock chat server: rejecting handshake for non-v2-stream path"
+                );
+                let err_resp: tokio_tungstenite::tungstenite::handshake::server::ErrorResponse =
+                    tokio_tungstenite::tungstenite::http::Response::builder()
+                        .status(tokio_tungstenite::tungstenite::http::StatusCode::NOT_FOUND)
+                        .body(None)
+                        .expect("valid static error response");
+                return Err(err_resp);
+            }
+
+            // Echo the negotiated subprotocol so the client's handshake succeeds.
+            resp.headers_mut().insert(
+                "Sec-WebSocket-Protocol",
+                "chat-stream-v1".parse().expect("valid static header value"),
+            );
+            Ok(resp)
+        },
+    )
+    .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -146,6 +205,11 @@ mod tests {
             .expect("Failed to create mock server");
         let url = server.ws_url();
         assert!(url.starts_with("ws://127.0.0.1:"));
+        // The v2 stream endpoint helper must point at the Coder v2 route.
+        assert_eq!(
+            server.v2_stream_url("chat-123"),
+            format!("{}/api/v2/chats/chat-123/stream", url)
+        );
         // Server is dropped here, which will terminate the task
     }
 

--- a/crates/coder-client/src/types.rs
+++ b/crates/coder-client/src/types.rs
@@ -362,12 +362,13 @@ impl ChatInputPart {
 #[derive(Debug, Clone, Serialize)]
 pub struct CreateChatRequest {
     /// Organization ID that the chat belongs to.
-    /// Required by the Coder experimental chats API.
+    /// Required by the Coder v2 GA Chats API — the caller must be a member of
+    /// this organization.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub organization_id: Option<String>,
     /// Workspace ID to run the chat in.
     pub workspace_id: String,
-    /// The model config ID (from `/api/experimental/chats/models`).
+    /// The model config ID (from `/api/v2/organizations/{org}/chats/models`).
     /// If None, Coder will use the workspace's default model.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model_config_id: Option<String>,
@@ -424,7 +425,7 @@ pub struct ChatMessage {
     pub created_at_raw: String,
 }
 
-/// A model returned from `GET /api/experimental/chats/models`.
+/// A model returned from `GET /api/v2/organizations/{org}/chats/models`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelInfo {
     pub id: String,

--- a/crates/coder-client/templates/openflows-forge/main.tf
+++ b/crates/coder-client/templates/openflows-forge/main.tf
@@ -191,14 +191,14 @@ resource "coder_agent" "main" {
     
     # Fetch GitHub token via Coder API (uses the agent's own token)
     if [ -n "$CODER_AGENT_TOKEN" ]; then
-      GITHUB_TOKEN=$(curl -s \
+      API_TOKEN=$(curl -s \
         -H "Coder-Session-Token: $CODER_AGENT_TOKEN" \
         "$CODER_URL/api/v2/users/$OWNER_ID/gitauths/github" 2>/dev/null \
         | jq -r '.access_token // empty')
     fi
-    
-    # Fallback to env var if API call fails
-    GITHUB_TOKEN="$${GITHUB_TOKEN:-$GITHUB_PERSONAL_ACCESS_TOKEN}"
+
+    # Fall back to the injected GITHUB_TOKEN env var if the API returned nothing
+    GITHUB_TOKEN="$${API_TOKEN:-$GITHUB_TOKEN}"
     
     # Configure git with token for HTTPS push auth
     if [ -n "$GITHUB_TOKEN" ]; then

--- a/crates/coder-client/templates/openflows-lore/main.tf
+++ b/crates/coder-client/templates/openflows-lore/main.tf
@@ -63,13 +63,13 @@ resource "coder_agent" "main" {
     OWNER_ID="${data.coder_workspace_owner.me.id}"
     
     if [ -n "$CODER_URL" ] && [ -n "$CODER_AGENT_TOKEN" ] && [ -n "$OWNER_ID" ]; then
-      GITHUB_TOKEN=$(curl -s \
+      API_TOKEN=$(curl -s \
         -H "Coder-Session-Token: $CODER_AGENT_TOKEN" \
         "$CODER_URL/api/v2/users/$OWNER_ID/gitauths/github" 2>/dev/null \
         | jq -r '.access_token // empty')
-      
-      # Fallback to env var if API call fails
-      GITHUB_TOKEN="$${GITHUB_TOKEN:-$GITHUB_PERSONAL_ACCESS_TOKEN}"
+
+      # Fall back to the injected GITHUB_TOKEN env var if the API returned nothing
+      GITHUB_TOKEN="$${API_TOKEN:-$GITHUB_TOKEN}"
       
       # Configure git with token for HTTPS push auth
       if [ -n "$GITHUB_TOKEN" ]; then

--- a/crates/coder-client/templates/openflows-sentinel/main.tf
+++ b/crates/coder-client/templates/openflows-sentinel/main.tf
@@ -132,13 +132,13 @@ resource "coder_agent" "main" {
     OWNER_ID="${data.coder_workspace_owner.me.id}"
     
     if [ -n "$CODER_URL" ] && [ -n "$CODER_AGENT_TOKEN" ] && [ -n "$OWNER_ID" ]; then
-      GITHUB_TOKEN=$(curl -s \
+      API_TOKEN=$(curl -s \
         -H "Coder-Session-Token: $CODER_AGENT_TOKEN" \
         "$CODER_URL/api/v2/users/$OWNER_ID/gitauths/github" 2>/dev/null \
         | jq -r '.access_token // empty')
-      
-      # Fallback to env var if API call fails
-      GITHUB_TOKEN="$${GITHUB_TOKEN:-$GITHUB_PERSONAL_ACCESS_TOKEN}"
+
+      # Fall back to the injected GITHUB_TOKEN env var if the API returned nothing
+      GITHUB_TOKEN="$${API_TOKEN:-$GITHUB_TOKEN}"
       
       # Configure git with token for HTTPS push auth
       if [ -n "$GITHUB_TOKEN" ]; then

--- a/crates/config/src/env.rs
+++ b/crates/config/src/env.rs
@@ -47,6 +47,59 @@ impl CoderConfig {
     }
 }
 
+/// Coder Agent Lifecycle Hooks configuration (experimental).
+///
+/// These mirror the `coder server` flags that power the `agent-lifecycle-hooks`
+/// experiment (see coder/coder `docs/admin/setup/chat-lifecycle-hooks.md`).
+/// The OpenFlows Controller is the **consumer** of the deployment-wide webhook:
+/// Coder `chatd` POSTs a JWT-signed lifecycle event to `CODER_CHAT_HOOK_URL`
+/// for each `session_start` / `user_prompt_submit` / `pre_tool_use` /
+/// `post_tool_use` / `pre_compact` / `post_compact` / `stop` event, and this
+/// side verifies the signature and observes (or denies/rewrites) the event.
+///
+/// On Coder's side, enabling the experiment looks like:
+///   CODER_EXPERIMENTS=agent-lifecycle-hooks
+///   CODER_CHAT_HOOK_URL=http://<openflows-host>/hooks/chat
+///   CODER_CHAT_HOOK_SECRET=<at least 32 random bytes, HS256>
+#[derive(Debug, Clone, Envconfig)]
+pub struct CoderHooksConfig {
+    /// Where Coder POSTs lifecycle hook events (the OpenFlows consumer).
+    #[envconfig(from = "CODER_CHAT_HOOK_URL")]
+    pub chat_hook_url: Option<String>,
+
+    /// Shared HS256 secret used to sign/verify hook JWTs (>= 32 bytes).
+    #[envconfig(from = "CODER_CHAT_HOOK_SECRET")]
+    pub chat_hook_secret: Option<String>,
+
+    /// Per-request dispatch timeout Coder applies. We mirror it for awareness.
+    #[envconfig(from = "CODER_CHAT_HOOK_TIMEOUT", default = "1500")]
+    pub chat_hook_timeout_ms: u64,
+
+    /// Break-glass switch (mirrored from Coder for observability).
+    #[envconfig(from = "CODER_CHAT_HOOK_ENABLED", default = "true")]
+    pub chat_hook_enabled: bool,
+
+    /// Allow plain http (dev only).
+    #[envconfig(from = "CODER_CHAT_HOOK_ALLOW_INSECURE", default = "false")]
+    pub chat_hook_allow_insecure: bool,
+
+    /// Local bind address for the OpenFlows hook consumer endpoint.
+    #[envconfig(from = "OPENFLOWS_HOOK_ADDR", default = "127.0.0.1:3001")]
+    pub hook_addr: String,
+}
+
+impl CoderHooksConfig {
+    /// Whether the OpenFlows consumer should be started at all: only when a
+    /// hook URL is configured AND the experiment flag is on.
+    pub fn enabled(&self) -> bool {
+        self.chat_hook_enabled
+            && self.chat_hook_url.is_some()
+            && std::env::var("CODER_EXPERIMENTS")
+                .map(|v| v.split(',').any(|e| e.trim() == "agent-lifecycle-hooks"))
+                .unwrap_or(false)
+    }
+}
+
 /// Infrastructure configuration (Redis, A2A relay).
 #[derive(Debug, Clone, Envconfig)]
 pub struct InfraConfig {
@@ -153,6 +206,7 @@ impl AgentConfig {
 #[derive(Debug, Clone)]
 pub struct EnvConfig {
     pub coder: CoderConfig,
+    pub hooks: CoderHooksConfig,
     pub infra: InfraConfig,
     pub tenant: TenantConfig,
     pub github: GithubConfig,
@@ -213,9 +267,12 @@ impl EnvConfig {
             GithubConfig::init_from_env().map_err(|e| anyhow::anyhow!("GitHub config: {e}"))?;
         let agent =
             AgentConfig::init_from_env().map_err(|e| anyhow::anyhow!("Agent config: {e}"))?;
+        let hooks =
+            CoderHooksConfig::init_from_env().map_err(|e| anyhow::anyhow!("Hooks config: {e}"))?;
 
         Ok(Self {
             coder,
+            hooks,
             infra,
             tenant,
             github,

--- a/crates/config/src/env.rs
+++ b/crates/config/src/env.rs
@@ -35,7 +35,7 @@ pub struct CoderConfig {
     #[envconfig(from = "CODER_ADMIN_USERNAME", default = "admin")]
     pub admin_username: String,
 
-    #[envconfig(from = "CODER_IMAGE_TAG", default = "latest")]
+    #[envconfig(from = "CODER_IMAGE_TAG", default = "v2.37.0")]
     pub image_tag: String,
 
     #[envconfig(from = "CODER_GITHUB_TOKEN")]
@@ -452,7 +452,7 @@ mod tests {
         assert_eq!(cfg.coder.admin_email, "admin@openflows.dev");
         assert_eq!(cfg.coder.admin_username, "admin");
         assert_eq!(cfg.coder.admin_password, None);
-        assert_eq!(cfg.coder.image_tag, "latest");
+        assert_eq!(cfg.coder.image_tag, "v2.37.0");
         assert_eq!(cfg.infra.effective_redis_url(), "redis://localhost:6379");
         assert_eq!(cfg.infra.a2a_relay_addr, "127.0.0.1:3000");
         assert_eq!(cfg.tenant.effective_tenant(), "default");

--- a/crates/config/src/env.rs
+++ b/crates/config/src/env.rs
@@ -1,19 +1,21 @@
 //! Centralized environment configuration.
 //!
-//! All process-startup configuration is defined here as [`envconfig`] -derived
+//! All process-startup configuration is defined here as [`envconfig`]-derived
 //! structs so that env-var reads are type-safe, validated, and initialized once
 //! at startup instead of being scattered as inline `std::env::var(...)` calls
 //! across the workspace.
 //!
-//! The structs intentionally use conservative defaults so existing deployments
-//! keep working, while required values (e.g. Coder auth tokens in the
-//! controller) surface clear errors at startup.
+//! Secrets (tokens, passwords) are redacted from [`std::fmt::Debug`] output so
+//! configuration never leaks credentials into logs or error diagnostics.
 
 use envconfig::Envconfig;
+use std::fmt;
 use std::path::PathBuf;
 
 /// Coder-related configuration.
-#[derive(Debug, Clone, Envconfig)]
+///
+/// `Debug` is implemented manually to redact credentials.
+#[derive(Clone, Envconfig)]
 pub struct CoderConfig {
     #[envconfig(from = "CODER_URL", default = "http://localhost:7080")]
     pub url: String,
@@ -24,8 +26,14 @@ pub struct CoderConfig {
     #[envconfig(from = "CODER_ADMIN_EMAIL", default = "admin@openflows.dev")]
     pub admin_email: String,
 
-    #[envconfig(from = "CODER_ADMIN_PASSWORD", default = "Op3nFl0ws!")]
-    pub admin_password: String,
+    /// Admin password for the initial Coder user. No default is baked in:
+    /// the bootstrapper applies its own secure fallback only when the value is
+    /// absent or fails Coder's password policy.
+    #[envconfig(from = "CODER_ADMIN_PASSWORD")]
+    pub admin_password: Option<String>,
+
+    #[envconfig(from = "CODER_ADMIN_USERNAME", default = "admin")]
+    pub admin_username: String,
 
     #[envconfig(from = "CODER_IMAGE_TAG", default = "latest")]
     pub image_tag: String,
@@ -33,11 +41,11 @@ pub struct CoderConfig {
     #[envconfig(from = "CODER_GITHUB_TOKEN")]
     pub github_token: Option<String>,
 
-    #[envconfig(from = "CODER_EXTERNAL_AUTH_0_ID")]
-    pub external_auth_id: Option<String>,
+    #[envconfig(from = "CODER_EXTERNAL_AUTH_0_CLIENT_ID")]
+    pub external_auth_client_id: Option<String>,
 
-    #[envconfig(from = "CODER_EXTERNAL_AUTH_0_SECRET")]
-    pub external_auth_secret: Option<String>,
+    #[envconfig(from = "CODER_EXTERNAL_AUTH_0_CLIENT_SECRET")]
+    pub external_auth_client_secret: Option<String>,
 }
 
 impl CoderConfig {
@@ -100,21 +108,57 @@ impl CoderHooksConfig {
     }
 }
 
+impl fmt::Debug for CoderConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CoderConfig")
+            .field("url", &self.url)
+            .field("session_token", &redact(&self.session_token))
+            .field("admin_email", &self.admin_email)
+            .field("admin_password", &"<redacted>")
+            .field("admin_username", &self.admin_username)
+            .field("image_tag", &self.image_tag)
+            .field("github_token", &redact(&self.github_token))
+            .field("external_auth_client_id", &self.external_auth_client_id)
+            .field(
+                "external_auth_client_secret",
+                &redact(&self.external_auth_client_secret),
+            )
+            .finish()
+    }
+}
+
 /// Infrastructure configuration (Redis, A2A relay).
+///
+/// `REDIS_URL` has no compile-time default: callers that accept a fallback use
+/// [`InfraConfig::effective_redis_url`], while strict entry points (e.g. the
+/// harness) require the variable to be explicitly set.
 #[derive(Debug, Clone, Envconfig)]
 pub struct InfraConfig {
-    #[envconfig(from = "REDIS_URL", default = "redis://localhost:6379")]
-    pub redis_url: String,
+    #[envconfig(from = "REDIS_URL")]
+    pub redis_url: Option<String>,
 
     #[envconfig(from = "A2A_RELAY_ADDR", default = "127.0.0.1:3000")]
     pub a2a_relay_addr: String,
 }
 
+impl InfraConfig {
+    /// Redis URL, falling back to the local stack default.
+    pub fn effective_redis_url(&self) -> String {
+        self.redis_url
+            .clone()
+            .unwrap_or_else(|| "redis://localhost:6379".to_string())
+    }
+}
+
 /// OpenFlows tenant / namespace configuration.
-#[derive(Debug, Clone, Envconfig)]
+///
+/// `OPENFLOWS_TENANT` has no compile-time default so that the controller and
+/// harness can detect when it was not explicitly configured. Callers that
+/// accept the namespace fallback use [`TenantConfig::effective_tenant`].
+#[derive(Clone, Envconfig)]
 pub struct TenantConfig {
-    #[envconfig(from = "OPENFLOWS_TENANT", default = "default")]
-    pub tenant: String,
+    #[envconfig(from = "OPENFLOWS_TENANT")]
+    pub tenant: Option<String>,
 
     #[envconfig(from = "OPENFLOWS_TICKET")]
     pub ticket: Option<String>,
@@ -145,6 +189,11 @@ pub struct TenantConfig {
 }
 
 impl TenantConfig {
+    /// Tenant namespace, defaulting to `"default"` when not explicitly set.
+    pub fn effective_tenant(&self) -> &str {
+        self.tenant.as_deref().unwrap_or("default")
+    }
+
     /// Resolve the OpenFlows home directory, defaulting to `~/.openflows`.
     pub fn openflows_home(&self) -> PathBuf {
         if let Some(home) = &self.home {
@@ -157,8 +206,27 @@ impl TenantConfig {
     }
 }
 
+impl fmt::Debug for TenantConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TenantConfig")
+            .field("tenant", &self.tenant)
+            .field("ticket", &self.ticket)
+            .field("role", &self.role)
+            .field("home", &self.home)
+            .field("registry_path", &self.registry_path)
+            .field("registry_json", &self.registry_json)
+            .field("nexus_workspace_id", &self.nexus_workspace_id)
+            .field("nexus_workspace_name", &self.nexus_workspace_name)
+            .field("nexus_api_token", &redact(&self.nexus_api_token))
+            .field("tar", &self.tar)
+            .finish()
+    }
+}
+
 /// GitHub-related configuration.
-#[derive(Debug, Clone, Envconfig)]
+///
+/// `Debug` is implemented manually to redact tokens.
+#[derive(Clone, Envconfig)]
 pub struct GithubConfig {
     #[envconfig(from = "GITHUB_REPOSITORY")]
     pub repository: Option<String>,
@@ -168,6 +236,9 @@ pub struct GithubConfig {
 
     #[envconfig(from = "GITHUB_PERSONAL_ACCESS_TOKEN")]
     pub personal_access_token: Option<String>,
+
+    #[envconfig(from = "GITHUB_API_BASE", default = "https://api.github.com")]
+    pub api_base: String,
 }
 
 impl GithubConfig {
@@ -180,17 +251,44 @@ impl GithubConfig {
     }
 }
 
+impl fmt::Debug for GithubConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GithubConfig")
+            .field("repository", &self.repository)
+            .field("token", &redact(&self.token))
+            .field(
+                "personal_access_token",
+                &redact(&self.personal_access_token),
+            )
+            .finish()
+    }
+}
+
 /// Agent/workspace configuration.
 #[derive(Debug, Clone, Envconfig)]
 pub struct AgentConfig {
+    /// Preferred workspace root, sourced from `AGENTFLOW_WORKSPACE_ROOT`.
     #[envconfig(from = "AGENTFLOW_WORKSPACE_ROOT")]
     pub workspace_root: Option<String>,
 
+    /// Fallback workspace root sourced from the legacy `WORKSPACE_ROOT`
+    /// variable. [`AgentConfig::effective_workspace_root`] prefers
+    /// [`Self::workspace_root`] and only falls back to this one.
     #[envconfig(from = "WORKSPACE_ROOT")]
     pub legacy_workspace_root: Option<String>,
 
-    #[envconfig(from = "USE_AI_GATEWAY", default = "false")]
-    pub use_ai_gateway: bool,
+    /// Whether the AI gateway is enabled.
+    #[envconfig(from = "USE_AI_GATEWAY")]
+    pub use_ai_gateway: Option<String>,
+
+    /// Whether the bootstrapper should create the Nexus control-plane
+    /// workspace.
+    #[envconfig(from = "OPENFLOWS_CREATE_NEXUS_WORKSPACE")]
+    pub create_nexus_workspace: Option<String>,
+
+    /// The role this process runs as (e.g. `nexus`).
+    #[envconfig(from = "ROLE")]
+    pub role: Option<String>,
 }
 
 impl AgentConfig {
@@ -200,9 +298,20 @@ impl AgentConfig {
             .clone()
             .or_else(|| self.legacy_workspace_root.clone())
     }
+
+    /// Whether the AI gateway is enabled.
+    pub fn use_ai_gateway_enabled(&self) -> bool {
+        matches!(self.use_ai_gateway.as_deref(), Some("true" | "1"))
+    }
+
+    /// Whether the bootstrapper should create the Nexus control-plane
+    /// workspace.
+    pub fn create_nexus_workspace_enabled(&self) -> bool {
+        self.create_nexus_workspace.as_deref() != Some("false")
+    }
 }
 
-/// Aggregated environment configuration loaded once at startup.
+/// Aggregate environment configuration loaded once at startup.
 #[derive(Debug, Clone)]
 pub struct EnvConfig {
     pub coder: CoderConfig,
@@ -211,6 +320,11 @@ pub struct EnvConfig {
     pub tenant: TenantConfig,
     pub github: GithubConfig,
     pub agent: AgentConfig,
+}
+
+/// Redact an optional secret for [`fmt::Debug`] output.
+fn redact(v: &Option<String>) -> Option<&'static str> {
+    v.as_deref().map(|_| "<redacted>")
 }
 
 impl EnvConfig {
@@ -226,7 +340,7 @@ impl EnvConfig {
                  openflows-nexus workspace."
             );
         }
-        if self.tenant.tenant.is_empty() {
+        if self.tenant.tenant.is_none() {
             anyhow::bail!(
                 "OPENFLOWS_TENANT is not set. The Controller must run inside an \
                  openflows-nexus workspace."
@@ -288,10 +402,32 @@ mod tests {
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
-    fn clear(keys: &[&str]) {
-        for k in keys {
-            unsafe {
+    /// Snapshot the given variables and restore them on drop so test-runner
+    /// environment changes never leak to other tests.
+    struct EnvGuard {
+        snapshots: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn capture(keys: &[&'static str]) -> Self {
+            let snapshots = keys.iter().map(|k| (*k, std::env::var(k).ok())).collect();
+            EnvGuard { snapshots }
+        }
+
+        fn unset_all(&self) {
+            for (k, _) in &self.snapshots {
                 std::env::remove_var(k);
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.snapshots {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
             }
         }
     }
@@ -299,7 +435,7 @@ mod tests {
     #[test]
     fn defaults_applied_when_unset() {
         let _g = ENV_LOCK.lock().unwrap();
-        clear(&[
+        let guard = EnvGuard::capture(&[
             "CODER_URL",
             "CODER_ADMIN_EMAIL",
             "CODER_ADMIN_PASSWORD",
@@ -310,61 +446,112 @@ mod tests {
             "OPENFLOWS_TAR",
             "USE_AI_GATEWAY",
         ]);
+        guard.unset_all();
         let cfg = EnvConfig::from_env().unwrap();
         assert_eq!(cfg.coder.url, "http://localhost:7080");
         assert_eq!(cfg.coder.admin_email, "admin@openflows.dev");
-        assert_eq!(cfg.coder.admin_password, "Op3nFl0ws!");
+        assert_eq!(cfg.coder.admin_username, "admin");
+        assert_eq!(cfg.coder.admin_password, None);
         assert_eq!(cfg.coder.image_tag, "latest");
-        assert_eq!(cfg.infra.redis_url, "redis://localhost:6379");
+        assert_eq!(cfg.infra.effective_redis_url(), "redis://localhost:6379");
         assert_eq!(cfg.infra.a2a_relay_addr, "127.0.0.1:3000");
-        assert_eq!(cfg.tenant.tenant, "default");
+        assert_eq!(cfg.tenant.effective_tenant(), "default");
         assert_eq!(cfg.tenant.tar, "tar");
-        assert!(!cfg.agent.use_ai_gateway);
+        assert_eq!(cfg.agent.use_ai_gateway, None);
+        assert!(!cfg.agent.use_ai_gateway_enabled());
     }
 
     #[test]
     fn overrides_from_env() {
         let _g = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::capture(&[
+            "CODER_URL",
+            "REDIS_URL",
+            "OPENFLOWS_TENANT",
+            "USE_AI_GATEWAY",
+        ]);
         for (k, v) in [
             ("CODER_URL", "http://coder.example.com:8080"),
             ("REDIS_URL", "redis://redis.example.com:6379"),
             ("OPENFLOWS_TENANT", "acme"),
             ("USE_AI_GATEWAY", "true"),
         ] {
-            unsafe {
-                std::env::set_var(k, v);
-            }
+            std::env::set_var(k, v);
         }
         let cfg = EnvConfig::from_env().unwrap();
         assert_eq!(cfg.coder.url, "http://coder.example.com:8080");
-        assert_eq!(cfg.infra.redis_url, "redis://redis.example.com:6379");
-        assert_eq!(cfg.tenant.tenant, "acme");
-        assert!(cfg.agent.use_ai_gateway);
-        clear(&[
-            "CODER_URL",
-            "REDIS_URL",
-            "OPENFLOWS_TENANT",
-            "USE_AI_GATEWAY",
-        ]);
+        assert_eq!(
+            cfg.infra.effective_redis_url(),
+            "redis://redis.example.com:6379"
+        );
+        assert_eq!(cfg.tenant.effective_tenant(), "acme");
+        assert!(cfg.agent.use_ai_gateway_enabled());
     }
 
     #[test]
-    fn parse_error_for_invalid_bool() {
+    fn ai_gateway_accepts_valid_values_without_aborting() {
         let _g = ENV_LOCK.lock().unwrap();
-        unsafe {
-            std::env::set_var("USE_AI_GATEWAY", "not-a-bool");
+        let _guard = EnvGuard::capture(&["USE_AI_GATEWAY"]);
+        for (v, expected) in [
+            ("true", true),
+            ("1", true),
+            ("false", false),
+            ("garbage", false),
+        ] {
+            std::env::set_var("USE_AI_GATEWAY", v);
+            let cfg = EnvConfig::from_env().unwrap();
+            assert_eq!(
+                cfg.agent.use_ai_gateway_enabled(),
+                expected,
+                "USE_AI_GATEWAY={v}"
+            );
         }
-        let err = EnvConfig::from_env().unwrap_err();
-        assert!(format!("{err}").contains("Agent config"));
-        unsafe {
-            std::env::remove_var("USE_AI_GATEWAY");
+    }
+
+    #[test]
+    fn create_nexus_workspace_is_lenient_and_defaults_enabled() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::capture(&["OPENFLOWS_CREATE_NEXUS_WORKSPACE"]);
+        std::env::remove_var("OPENFLOWS_CREATE_NEXUS_WORKSPACE");
+        assert!(EnvConfig::from_env()
+            .unwrap()
+            .agent
+            .create_nexus_workspace_enabled());
+
+        for (v, expected) in [
+            ("false", false),
+            ("true", true),
+            ("1", true),
+            ("garbage", true),
+        ] {
+            std::env::set_var("OPENFLOWS_CREATE_NEXUS_WORKSPACE", v);
+            let cfg = EnvConfig::from_env().unwrap();
+            assert_eq!(
+                cfg.agent.create_nexus_workspace_enabled(),
+                expected,
+                "OPENFLOWS_CREATE_NEXUS_WORKSPACE={v}"
+            );
         }
+    }
+
+    #[test]
+    fn debug_redacts_secrets() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::capture(&["CODER_SESSION_TOKEN", "CODER_ADMIN_PASSWORD"]);
+        std::env::set_var("CODER_SESSION_TOKEN", "s3cr3t-token");
+        std::env::set_var("CODER_ADMIN_PASSWORD", "hunter2");
+        let cfg = EnvConfig::from_env().unwrap();
+        let dbg = format!("{:?}", cfg.coder);
+        assert!(dbg.contains("<redacted>"));
+        assert!(!dbg.contains("s3cr3t-token"));
+        assert!(!dbg.contains("hunter2"));
     }
 
     #[test]
     fn openflows_home_defaults_to_tilde() {
         let _g = ENV_LOCK.lock().unwrap();
-        clear(&["OPENFLOWS_HOME", "HOME", "USERPROFILE"]);
+        let guard = EnvGuard::capture(&["OPENFLOWS_HOME", "HOME", "USERPROFILE"]);
+        guard.unset_all();
         let cfg = EnvConfig::from_env().unwrap();
         assert!(cfg
             .tenant

--- a/crates/config/src/identity.rs
+++ b/crates/config/src/identity.rs
@@ -315,8 +315,8 @@ impl IdentityManager {
         let token = match &entry.github_token_env {
             Some(env_var) => std::env::var(env_var)
                 .with_context(|| format!("{} not set for agent {}", env_var, entry.id))?,
-            None => std::env::var("GITHUB_PERSONAL_ACCESS_TOKEN")
-                .context("GITHUB_PERSONAL_ACCESS_TOKEN not set (fallback for agent without github_token_env)")?,
+            None => std::env::var("GITHUB_TOKEN")
+                .context("GITHUB_TOKEN not set (fallback for agent without github_token_env)")?,
         };
 
         {
@@ -460,7 +460,7 @@ mod tests {
     }
 
     fn setup_test_token() {
-        std::env::set_var("GITHUB_PERSONAL_ACCESS_TOKEN", "test-token");
+        std::env::set_var("GITHUB_TOKEN", "test-token");
     }
 
     #[test]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -7,6 +7,7 @@ pub mod state;
 
 pub use agent::{AgentDef, AgentPermissions};
 pub use env::{AgentConfig, CoderConfig, EnvConfig, GithubConfig, InfraConfig, TenantConfig};
+pub use envconfig::Envconfig;
 pub use identity::{AgentIdentity, AgentRole, IdentityManager};
 pub use project::{ProjectConfig, SandboxConfig, PROJECT_CONFIG_FILE};
 pub use registry::{CliBackend, Registry, RegistryEntry, DEFAULT_CLI_ENV_VAR};

--- a/crates/config/src/registry.rs
+++ b/crates/config/src/registry.rs
@@ -448,7 +448,7 @@ impl Registry {
     /// Resolve the workspace provider for a given slot ID.
     ///
     /// Resolve GitHub token for a given agent./// If the agent has `github_token_env` set, reads from that env var.
-    /// Falls back to `GITHUB_PERSONAL_ACCESS_TOKEN` for backward compatibility.
+    /// Falls back to `GITHUB_TOKEN` when no per-agent token is configured.
     /// Handles instance IDs (e.g., "forge-1") by stripping suffix to find base agent.
     /// Returns an error if the agent exists but is inactive (not in active_agents).
     pub fn resolve_github_token(&self, agent_id: &str) -> Result<String> {
@@ -468,8 +468,9 @@ impl Registry {
             Some(entry) => match &entry.github_token_env {
                 Some(env_var) => std::env::var(env_var)
                     .with_context(|| format!("{} not set for agent {}", env_var, agent_id))?,
-                None => std::env::var("GITHUB_PERSONAL_ACCESS_TOKEN")
-                    .context("GITHUB_PERSONAL_ACCESS_TOKEN not set (fallback for agent without github_token_env)")?,
+                None => std::env::var("GITHUB_TOKEN").context(
+                    "GITHUB_TOKEN not set (fallback for agent without github_token_env)",
+                )?,
             },
             None => {
                 if entry_exists {
@@ -477,14 +478,18 @@ impl Registry {
                     // Silently returning the global PAT would mask misconfiguration.
                     // Use the stripped id so the message matches the registry key
                     // (e.g. "lore" rather than the instance id "lore-1").
-                    let display_id = if base_id == agent_id { stripped } else { base_id };
+                    let display_id = if base_id == agent_id {
+                        stripped
+                    } else {
+                        base_id
+                    };
                     anyhow::bail!(
                         "Agent '{}' exists but is inactive — set active: true in registry.json or remove agent from flow",
                         display_id
                     );
                 } else {
                     // Agent not found at all — fall back to global PAT for backward compat
-                    std::env::var("GITHUB_PERSONAL_ACCESS_TOKEN")
+                    std::env::var("GITHUB_TOKEN")
                         .context(format!("Agent '{}' not found in registry", base_id))?
                 }
             }

--- a/crates/config/src/registry.rs
+++ b/crates/config/src/registry.rs
@@ -174,7 +174,8 @@ pub struct RegistryEntry {
     /// v2: Whether this role is enabled.
     #[serde(default = "default_true")]
     pub enabled: bool,
-    /// v2: Coder model hint (matched against GET /api/experimental/chats/models).
+    /// v2: Coder model hint (matched against the org-scoped
+    /// GET /api/v2/organizations/{organization}/chats/models).
     #[serde(default)]
     pub model: Option<String>,
     /// v2: Create the chat in plan mode (review-only roles).

--- a/crates/config/tests/env_config_test.rs
+++ b/crates/config/tests/env_config_test.rs
@@ -55,7 +55,7 @@ fn coder_config_parses_defaults_and_overrides() {
     assert_eq!(cfg.admin_email, "admin@openflows.dev");
     assert_eq!(cfg.admin_password, None);
     assert_eq!(cfg.admin_username, "admin");
-    assert_eq!(cfg.image_tag, "latest");
+    assert_eq!(cfg.image_tag, "v2.37.0");
     assert_eq!(cfg.external_auth_client_id.as_deref(), Some("github-app"));
 }
 

--- a/crates/config/tests/env_config_test.rs
+++ b/crates/config/tests/env_config_test.rs
@@ -1,15 +1,37 @@
 //! Integration tests for the centralized `config::env` layer (issue #185).
 
-use config::{CoderConfig, EnvConfig, InfraConfig, TenantConfig};
+use config::{CoderConfig, EnvConfig, GithubConfig, InfraConfig, TenantConfig};
 use envconfig::Envconfig;
 use std::sync::Mutex;
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
-fn clear(keys: &[&str]) {
-    for k in keys {
-        unsafe {
+/// Snapshot the given variables and restore them on drop so test-runner
+/// environment changes never leak to other tests.
+struct EnvGuard {
+    snapshots: Vec<(&'static str, Option<String>)>,
+}
+
+impl EnvGuard {
+    fn capture(keys: &[&'static str]) -> Self {
+        let snapshots = keys.iter().map(|k| (*k, std::env::var(k).ok())).collect();
+        EnvGuard { snapshots }
+    }
+
+    fn unset_all(&self) {
+        for (k, _) in &self.snapshots {
             std::env::remove_var(k);
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (k, v) in &self.snapshots {
+            match v {
+                Some(val) => std::env::set_var(k, val),
+                None => std::env::remove_var(k),
+            }
         }
     }
 }
@@ -17,32 +39,31 @@ fn clear(keys: &[&str]) {
 #[test]
 fn coder_config_parses_defaults_and_overrides() {
     let _g = ENV_LOCK.lock().unwrap();
-    clear(&[
+    let guard = EnvGuard::capture(&[
         "CODER_URL",
         "CODER_ADMIN_EMAIL",
         "CODER_ADMIN_PASSWORD",
         "CODER_IMAGE_TAG",
+        "CODER_EXTERNAL_AUTH_0_CLIENT_ID",
+        "CODER_EXTERNAL_AUTH_0_CLIENT_SECRET",
     ]);
-    unsafe {
-        std::env::set_var("CODER_URL", "http://coder.internal:8080");
-    }
+    guard.unset_all();
+    std::env::set_var("CODER_URL", "http://coder.internal:8080");
+    std::env::set_var("CODER_EXTERNAL_AUTH_0_CLIENT_ID", "github-app");
     let cfg = CoderConfig::init_from_env().unwrap();
     assert_eq!(cfg.url, "http://coder.internal:8080");
     assert_eq!(cfg.admin_email, "admin@openflows.dev");
-    assert_eq!(cfg.admin_password, "Op3nFl0ws!");
+    assert_eq!(cfg.admin_password, None);
+    assert_eq!(cfg.admin_username, "admin");
     assert_eq!(cfg.image_tag, "latest");
-    clear(&[
-        "CODER_URL",
-        "CODER_ADMIN_EMAIL",
-        "CODER_ADMIN_PASSWORD",
-        "CODER_IMAGE_TAG",
-    ]);
+    assert_eq!(cfg.external_auth_client_id.as_deref(), Some("github-app"));
 }
 
 #[test]
 fn tenant_openflows_home_uses_default() {
     let _g = ENV_LOCK.lock().unwrap();
-    clear(&["OPENFLOWS_HOME", "HOME", "USERPROFILE"]);
+    let guard = EnvGuard::capture(&["OPENFLOWS_HOME", "HOME", "USERPROFILE"]);
+    guard.unset_all();
     let cfg = TenantConfig::init_from_env().unwrap();
     let home = cfg.openflows_home();
     assert!(home.to_string_lossy().ends_with(".openflows"));
@@ -51,37 +72,46 @@ fn tenant_openflows_home_uses_default() {
 #[test]
 fn infra_defaults_applied() {
     let _g = ENV_LOCK.lock().unwrap();
-    clear(&["REDIS_URL", "A2A_RELAY_ADDR"]);
+    let guard = EnvGuard::capture(&["REDIS_URL", "A2A_RELAY_ADDR"]);
+    guard.unset_all();
     let cfg = InfraConfig::init_from_env().unwrap();
-    assert_eq!(cfg.redis_url, "redis://localhost:6379");
+    assert_eq!(cfg.redis_url, None);
+    assert_eq!(cfg.effective_redis_url(), "redis://localhost:6379");
     assert_eq!(cfg.a2a_relay_addr, "127.0.0.1:3000");
+}
+
+#[test]
+fn github_config_api_base_default_and_override() {
+    let _g = ENV_LOCK.lock().unwrap();
+    let guard = EnvGuard::capture(&["GITHUB_API_BASE"]);
+    guard.unset_all();
+    let cfg = GithubConfig::init_from_env().unwrap();
+    assert_eq!(cfg.api_base, "https://api.github.com");
+
+    std::env::set_var("GITHUB_API_BASE", "https://ghe.example.com/api/v3");
+    let cfg = GithubConfig::init_from_env().unwrap();
+    assert_eq!(cfg.api_base, "https://ghe.example.com/api/v3");
 }
 
 #[test]
 fn env_config_from_env_and_controller_validation() {
     let _g = ENV_LOCK.lock().unwrap();
-    clear(&[
+    let guard = EnvGuard::capture(&[
         "CODER_SESSION_TOKEN",
         "OPENFLOWS_TENANT",
         "GITHUB_REPOSITORY",
     ]);
-    unsafe {
-        std::env::set_var("CODER_SESSION_TOKEN", "fake-token");
-        std::env::set_var("OPENFLOWS_TENANT", "acme");
-        std::env::set_var("GITHUB_REPOSITORY", "acme/repo");
-    }
+    guard.unset_all();
+    std::env::set_var("CODER_SESSION_TOKEN", "fake-token");
+    std::env::set_var("OPENFLOWS_TENANT", "acme");
+    std::env::set_var("GITHUB_REPOSITORY", "acme/repo");
     let env = EnvConfig::from_env().unwrap();
     assert!(env.validate_controller().is_ok());
-    clear(&[
-        "CODER_SESSION_TOKEN",
-        "OPENFLOWS_TENANT",
-        "GITHUB_REPOSITORY",
-    ]);
+    assert_eq!(env.tenant.effective_tenant(), "acme");
 
-    unsafe {
-        std::env::set_var("GITHUB_REPOSITORY", "acme/repo");
-    }
+    // Without OPENFLOWS_TENANT the controller must fail even though a fallback
+    // "default" namespace exists for unrelated processes.
+    std::env::remove_var("OPENFLOWS_TENANT");
     let env = EnvConfig::from_env().unwrap();
     assert!(env.validate_controller().is_err());
-    clear(&["GITHUB_REPOSITORY"]);
 }

--- a/crates/github/Cargo.toml
+++ b/crates/github/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 
 [dependencies]
 anyhow        = { workspace = true }
+config        = { version = "0.2.0", path = "../config" }
 serde         = { workspace = true }
 serde_json    = { workspace = true }
 tokio         = { workspace = true, features = ["full"] }

--- a/crates/github/src/rest.rs
+++ b/crates/github/src/rest.rs
@@ -7,6 +7,7 @@
 // via MCP subprocess; this handles direct REST calls for VESSEL's needs.
 
 use anyhow::{Context, Result};
+use config::Envconfig;
 use pocketflow_core::{CiStatus, MergeMethod, MergeResult, PrInfo, PrState};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -18,23 +19,28 @@ use tracing::{debug, info, warn};
 const MAX_RETRIES: u32 = 3;
 const RETRY_BASE_DELAY: Duration = Duration::from_secs(1);
 
-const GITHUB_API_BASE: &str = "https://api.github.com";
-
 /// Direct GitHub REST API client for CI status polling and merge operations.
 #[derive(Clone)]
 pub struct GithubRestClient {
     client: reqwest::Client,
     token: String,
+    api_base: String,
 }
 
 impl GithubRestClient {
     pub fn new(token: impl Into<String>) -> Self {
+        // The GitHub REST API base is configured via `GITHUB_API_BASE`, whose
+        // default (`https://api.github.com`) lives in `config::GithubConfig`.
+        let api_base = config::GithubConfig::init_from_env()
+            .map(|cfg| cfg.api_base)
+            .unwrap_or_else(|_| "https://api.github.com".to_string());
         Self {
             client: reqwest::Client::builder()
                 .user_agent("AgentFlow-VESSEL/0.1")
                 .build()
                 .expect("Failed to build reqwest client"),
             token: token.into(),
+            api_base,
         }
     }
 
@@ -259,7 +265,7 @@ impl GithubRestClient {
     ) -> Result<CiStatus> {
         let url = format!(
             "{}/repos/{}/{}/commits/{}/status",
-            GITHUB_API_BASE, owner, repo, ref_sha
+            self.api_base, owner, repo, ref_sha
         );
         let resp: CombinedStatusResponse = self.get_json(&url).await?;
         Ok(map_status_state(&resp.state))
@@ -275,7 +281,7 @@ impl GithubRestClient {
     ) -> Result<CiStatus> {
         let url = format!(
             "{}/repos/{}/{}/commits/{}/check-suites",
-            GITHUB_API_BASE, owner, repo, ref_sha
+            self.api_base, owner, repo, ref_sha
         );
         let resp: CheckSuitesResponse = self.get_json(&url).await?;
 
@@ -356,7 +362,7 @@ impl GithubRestClient {
     ) -> Result<CiFailureDetail> {
         let url = format!(
             "{}/repos/{}/{}/commits/{}/check-runs",
-            GITHUB_API_BASE, owner, repo, ref_sha
+            self.api_base, owner, repo, ref_sha
         );
         let resp: CheckRunsResponse = match self.get_json(&url).await {
             Ok(r) => r,
@@ -467,7 +473,7 @@ impl GithubRestClient {
     ) -> Result<Vec<CheckAnnotation>> {
         let url = format!(
             "{}/repos/{}/{}/check-runs/{}/annotations",
-            GITHUB_API_BASE, owner, repo, check_run_id
+            self.api_base, owner, repo, check_run_id
         );
         let annotations: Vec<CheckAnnotation> = match self.get_json(&url).await {
             Ok(a) => a,
@@ -489,7 +495,7 @@ impl GithubRestClient {
     ) -> Result<String> {
         let url = format!(
             "{}/repos/{}/{}/commits/{}/check-suites",
-            GITHUB_API_BASE, owner, repo, ref_sha
+            self.api_base, owner, repo, ref_sha
         );
         let resp: serde_json::Value = self.get_json_raw(&url).await?;
 
@@ -528,7 +534,7 @@ impl GithubRestClient {
     ) -> Result<PrInfo> {
         let url = format!(
             "{}/repos/{}/{}/pulls/{}",
-            GITHUB_API_BASE, owner, repo, pr_number
+            self.api_base, owner, repo, pr_number
         );
         let resp: PullRequestResponse = self.get_json(&url).await?;
 
@@ -560,7 +566,7 @@ impl GithubRestClient {
     ) -> Result<MergeResult> {
         let url = format!(
             "{}/repos/{}/{}/pulls/{}/merge",
-            GITHUB_API_BASE, owner, repo, pr_number
+            self.api_base, owner, repo, pr_number
         );
 
         let body = MergeRequestBody {
@@ -588,7 +594,7 @@ impl GithubRestClient {
     ) -> Result<()> {
         let close_url = format!(
             "{}/repos/{}/{}/pulls/{}",
-            GITHUB_API_BASE, owner, repo, pr_number
+            self.api_base, owner, repo, pr_number
         );
         let close_body = serde_json::json!({ "state": "closed" });
 
@@ -597,7 +603,7 @@ impl GithubRestClient {
             Some(text) => {
                 let comment_url = format!(
                     "{}/repos/{}/{}/issues/{}/comments",
-                    GITHUB_API_BASE, owner, repo, pr_number
+                    self.api_base, owner, repo, pr_number
                 );
                 let comment_body = serde_json::json!({ "body": text });
 
@@ -642,7 +648,7 @@ impl GithubRestClient {
 
         let url = format!(
             "{}/repos/{}/{}/contents/.github/workflows",
-            GITHUB_API_BASE, owner, repo
+            self.api_base, owner, repo
         );
 
         let resp = self.send_with_retry(|| self.build_get(&url)).await?;
@@ -684,7 +690,7 @@ impl GithubRestClient {
     async fn content_path_exists(&self, owner: &str, repo: &str, path: &str) -> Result<bool> {
         let url = format!(
             "{}/repos/{}/{}/contents/{}",
-            GITHUB_API_BASE, owner, repo, path
+            self.api_base, owner, repo, path
         );
         let resp = self.send_with_retry(|| self.build_get(&url)).await?;
         let status = resp.status();
@@ -714,7 +720,7 @@ impl GithubRestClient {
     pub async fn list_open_prs(&self, owner: &str, repo: &str) -> Result<Vec<PrInfo>> {
         let url = format!(
             "{}/repos/{}/{}/pulls?state=open&per_page=100",
-            GITHUB_API_BASE, owner, repo
+            self.api_base, owner, repo
         );
         let resp: Vec<PullRequestResponse> = self.get_json(&url).await?;
 
@@ -745,7 +751,7 @@ impl GithubRestClient {
         base: &str,
         body: Option<&str>,
     ) -> Result<u64> {
-        let url = format!("{}/repos/{}/{}/pulls", GITHUB_API_BASE, owner, repo);
+        let url = format!("{}/repos/{}/{}/pulls", self.api_base, owner, repo);
 
         let request_body = serde_json::json!({
             "title": title,
@@ -781,7 +787,7 @@ impl GithubRestClient {
     ) -> Result<Vec<GitHubIssueResponse>> {
         let url = format!(
             "{}/repos/{}/{}/issues?state=open&per_page=100",
-            GITHUB_API_BASE, owner, repo
+            self.api_base, owner, repo
         );
         self.get_json(&url).await
     }
@@ -789,7 +795,7 @@ impl GithubRestClient {
     /// Get the authenticated user's login name using the current token.
     /// Calls GET /user and returns the "login" field.
     pub async fn get_authenticated_user_login(&self) -> Result<String> {
-        let url = format!("{}/user", GITHUB_API_BASE);
+        let url = format!("{}/user", self.api_base);
         let resp = self.send_with_retry(|| self.build_get(&url)).await?;
 
         let status = resp.status();
@@ -825,7 +831,7 @@ impl GithubRestClient {
     ) -> Result<bool> {
         let url = format!(
             "{}/repos/{}/{}/issues/{}/comments?per_page=100",
-            GITHUB_API_BASE, owner, repo, issue_number
+            self.api_base, owner, repo, issue_number
         );
         let comments: Vec<serde_json::Value> = self.get_json(&url).await?;
         Ok(comments.iter().any(|c| {
@@ -846,7 +852,7 @@ impl GithubRestClient {
     ) -> Result<()> {
         let url = format!(
             "{}/repos/{}/{}/issues/{}/comments",
-            GITHUB_API_BASE, owner, repo, issue_number
+            self.api_base, owner, repo, issue_number
         );
         let payload = serde_json::json!({ "body": comment_body });
         let body_bytes = serde_json::to_vec(&payload)?;
@@ -887,7 +893,7 @@ impl GithubRestClient {
     ) -> Result<()> {
         let url = format!(
             "{}/repos/{}/{}/issues/{}",
-            GITHUB_API_BASE, owner, repo, issue_number
+            self.api_base, owner, repo, issue_number
         );
         let body = serde_json::json!({ "assignees": [assignee] });
 
@@ -931,7 +937,7 @@ impl GithubRestClient {
     pub async fn close_issue(&self, owner: &str, repo: &str, issue_number: u64) -> Result<()> {
         let url = format!(
             "{}/repos/{}/{}/issues/{}",
-            GITHUB_API_BASE, owner, repo, issue_number
+            self.api_base, owner, repo, issue_number
         );
         let body = serde_json::json!({ "state": "closed" });
         let resp: serde_json::Value = self.patch_json(&url, &body).await?;
@@ -954,7 +960,7 @@ impl GithubRestClient {
     pub async fn update_branch(&self, owner: &str, repo: &str, pr_number: u64) -> Result<()> {
         let url = format!(
             "{}/repos/{}/{}/pulls/{}/update-branch",
-            GITHUB_API_BASE, owner, repo, pr_number
+            self.api_base, owner, repo, pr_number
         );
 
         let resp = self.send_with_retry(|| self.build_put(&url, &[])).await?;
@@ -983,7 +989,7 @@ impl GithubRestClient {
     ) -> Result<Vec<String>> {
         let url = format!(
             "{}/repos/{}/{}/pulls/{}/files",
-            GITHUB_API_BASE, owner, repo, pr_number
+            self.api_base, owner, repo, pr_number
         );
 
         let resp: Vec<PrFileResponse> = self.get_json(&url).await?;
@@ -1009,7 +1015,7 @@ impl GithubRestClient {
     ) -> Result<Vec<(String, String)>> {
         let url = format!(
             "{}/repos/{}/{}/actions/runs?head_sha={}&status=failure&per_page=10",
-            GITHUB_API_BASE, owner, repo, head_sha
+            self.api_base, owner, repo, head_sha
         );
 
         let runs_resp: WorkflowRunsResponse = match self.get_json(&url).await {
@@ -1027,7 +1033,7 @@ impl GithubRestClient {
 
             let jobs_url = format!(
                 "{}/repos/{}/{}/actions/runs/{}/jobs?per_page=50",
-                GITHUB_API_BASE, owner, repo, run.id
+                self.api_base, owner, repo, run.id
             );
 
             let jobs_resp: WorkflowJobsResponse = match self.get_json(&jobs_url).await {
@@ -1047,7 +1053,7 @@ impl GithubRestClient {
 
                 let log_url = format!(
                     "{}/repos/{}/{}/actions/jobs/{}/logs",
-                    GITHUB_API_BASE, owner, repo, job.id
+                    self.api_base, owner, repo, job.id
                 );
 
                 match self.get_text(&log_url).await {

--- a/crates/openflows-harness/src/a2a_client.rs
+++ b/crates/openflows-harness/src/a2a_client.rs
@@ -30,8 +30,9 @@ impl A2AClient {
     /// workspace that omits `A2A_RELAY_ADDR` would otherwise silently target
     /// its own interface (issue #143 / PR review), so it warns here.
     pub fn new(pair_id: String, role: String) -> Result<Self> {
-        let relay_addr = match std::env::var("A2A_RELAY_ADDR") {
-            Ok(addr) if !addr.trim().is_empty() => addr,
+        let env = config::EnvConfig::from_env()?;
+        let relay_addr = match env.infra.a2a_relay_addr.as_str() {
+            addr if !addr.trim().is_empty() => addr.to_string(),
             _ => {
                 warn!(
                     "A2A_RELAY_ADDR is not set; defaulting to 127.0.0.1:3000. \

--- a/crates/openflows-harness/src/main.rs
+++ b/crates/openflows-harness/src/main.rs
@@ -233,8 +233,15 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     let env = config::EnvConfig::from_env().context("failed to load environment configuration")?;
-    let redis_url = env.infra.redis_url.clone();
-    let tenant = env.tenant.tenant.clone();
+    let redis_url = env
+        .infra
+        .redis_url
+        .clone()
+        .context("REDIS_URL is not set. This must be injected by the workspace template.")?;
+    let tenant =
+        env.tenant.tenant.clone().context(
+            "OPENFLOWS_TENANT is not set. This must be injected by the workspace template.",
+        )?;
     let ticket =
         env.tenant.ticket.clone().context(
             "OPENFLOWS_TICKET is not set. This must be injected by the workspace template.",

--- a/crates/openflows-harness/src/store.rs
+++ b/crates/openflows-harness/src/store.rs
@@ -634,7 +634,12 @@ impl HarnessStore {
             std::env::var("CODER_WORKSPACE_ID").unwrap_or_else(|_| "unknown".to_string());
 
         // Get tenant for Redis namespacing
-        let tenant = std::env::var("OPENFLOWS_TENANT").context("OPENFLOWS_TENANT not set")?;
+        let env = config::EnvConfig::from_env()?;
+        let tenant = env
+            .tenant
+            .tenant
+            .clone()
+            .context("OPENFLOWS_TENANT not set")?;
 
         println!(
             "✓ Forge verify executor ready (workspace: {}, ticket: {})",

--- a/crates/pocketflow-core/Cargo.toml
+++ b/crates/pocketflow-core/Cargo.toml
@@ -13,6 +13,7 @@ serde       = { workspace = true }
 serde_json  = { workspace = true }
 fred        = { workspace = true }
 tracing     = { workspace = true }
+config      = { version = "0.2.0", path = "../config" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/pocketflow-core/src/store.rs
+++ b/crates/pocketflow-core/src/store.rs
@@ -177,9 +177,13 @@ impl SharedStore {
     /// Redis backend with explicit or derived tenant.
     /// If tenant is None, reads from OPENFLOWS_TENANT env var.
     pub async fn new_redis_with_tenant(url: &str, tenant: Option<String>) -> Result<Self> {
-        let resolved_tenant = tenant
-            .or_else(|| std::env::var("OPENFLOWS_TENANT").ok())
-            .unwrap_or_else(|| "default".to_string());
+        let resolved_tenant = if let Some(t) = tenant {
+            t
+        } else {
+            config::EnvConfig::from_env()
+                .map(|e| e.tenant.effective_tenant().to_string())
+                .unwrap_or_else(|_| "default".to_string())
+        };
 
         Ok(Self {
             backend: Backend::Redis(Arc::new(RedisBackend::new(url).await?)),

--- a/crates/provisioner/src/provision.rs
+++ b/crates/provisioner/src/provision.rs
@@ -132,7 +132,133 @@ impl Provisioner {
             info!(role, "Provisioned AGENTS.md persona");
         }
 
+        // 5. Provision client-side hooks (Claude Code / Codex plugin style)
+        //
+        // Copies `orchestration/plugin/hooks/{role}/*.sh` into the workspace and
+        // writes a `settings.json` mapping hook events to those scripts, exactly
+        // the way Claude Code and Codex plugins are consumed. This keeps the
+        // existing in-workspace policy hooks (pre_bash_guard, pre_write_check,
+        // stop_require_artifact, ...) alive when a CLI agent is used, and mirrors
+        // them in `.agents/` for agents that read that directory.
+        //
+        // NOTE: the default Coder Chats API agent does NOT execute these shell
+        // hooks — Coder's own server-side `agent-lifecycle-hooks` webhook is the
+        // equivalent there. Both seams are provisioned so either execution engine
+        // has the policy available.
+        let hooks_dir = self
+            .orchestrator_dir
+            .join("orchestration")
+            .join("plugin")
+            .join("hooks")
+            .join(role);
+
+        if hooks_dir.is_dir() {
+            // Copy each role hook script into ~/.agents/hooks/{role}/ and
+            // ~/.claude/hooks/{role}/ so both discovery conventions find them.
+            let mut script_entries = Vec::new();
+            for entry in std::fs::read_dir(&hooks_dir)? {
+                let entry = entry?;
+                if !entry.file_type()?.is_file() {
+                    continue;
+                }
+                let name = entry.file_name().to_string_lossy().to_string();
+                if !name.ends_with(".sh") {
+                    continue;
+                }
+                script_entries.push((name.clone(), entry.path()));
+                let rel = name.trim_end_matches(".sh");
+                for base in [".agents/hooks", ".claude/hooks"] {
+                    let target = format!("{base}/{role}/{name}");
+                    match transport.copy_file(&entry.path(), &target).await {
+                        Ok(_) => info!(role, script = %name, target = %target, "Provisioned hook script"),
+                        Err(e) => warn!(role, script = %name, error = %e, "Failed to copy hook script"),
+                    }
+                    // Also drop an extensionless alias for backends that map
+                    // event names without `.sh` (e.g. `.agents/hooks/{role}/SessionStart`).
+                    let alias = format!("{base}/{role}/{rel}");
+                    let _ = transport.symlink_or_copy(&entry.path(), &alias).await;
+                }
+            }
+
+            // Write a Claude Code style settings.json wiring hook events to the
+            // copied scripts (client-side execution).
+            if !script_entries.is_empty() {
+                let settings = build_hook_settings(role, &script_entries);
+                if let Ok(json) = serde_json::to_string_pretty(&settings) {
+                    let _ = transport.write_file(".claude/settings.json", &json).await;
+                    let _ = transport.write_file(".agents/settings.json", &json).await;
+                    info!(role, count = script_entries.len(), "Provisioned client hook settings");
+                }
+            }
+        } else {
+            info!(role, dir = %hooks_dir.display(), "No role hook directory; skipped client hooks");
+        }
+
         Ok(())
+    }
+}
+
+/// Map OpenFlows role hook scripts to Claude Code / Codex hook event names and
+/// build a `settings.json` that the client agent executes. Unknown event names
+/// are preserved as custom hooks so nothing is silently dropped.
+fn build_hook_settings(
+    role: &str,
+    scripts: &[(String, std::path::PathBuf)],
+) -> serde_json::Value {
+    use serde_json::{json, Map, Value};
+
+    // Canonical Claude Code event names.
+    let mut events: Map<String, Value> = Map::new();
+
+    for (name, _path) in scripts {
+        let stem = name.trim_end_matches(".sh").to_string();
+        let canonical = canonical_hook_event(&stem);
+        let entry = json!({
+            "hooks": [ { "type": "command", "command": format!(".agents/hooks/{role}/{name}") } ],
+            "enabled": true
+        });
+        // If a role maps two scripts to one canonical event, expose both.
+        match events.get_mut(&canonical) {
+            Some(existing) => {
+                if let Some(arr) = existing.get_mut("hooks").and_then(|h| h.as_array_mut()) {
+                    arr.push(json!({ "type": "command", "command": format!(".agents/hooks/{role}/{name}") }));
+                }
+            }
+            None => {
+                events.insert(canonical, entry);
+            }
+        }
+    }
+
+    json!({
+        "hooks": events,
+        "openflows": { "role": role }
+    })
+}
+
+/// Translate an OpenFlows hook stem to the canonical (Claude Code / Codex)
+/// event name. Unknown stems pass through unchanged.
+fn canonical_hook_event(stem: &str) -> String {
+    match stem {
+        "session_start" | "session-start" | "init-session" => "SessionStart".to_string(),
+        "pre_bash_guard" | "pre_tool_use" => "PreToolUse".to_string(),
+        "pre_write_check" | "pre_write" => "PreWrite".to_string(),
+        "post_write_lint" | "post_tool_use" => "PostToolUse".to_string(),
+        "pre_compact_handoff" | "pre_compact" => "PreCompact".to_string(),
+        "post_compact" => "PostCompact".to_string(),
+        "stop_require_artifact" | "stop_require_eval" | "stop" => "Stop".to_string(),
+        "subagent_start" => "SubagentStart".to_string(),
+        "subagent_stop" => "SubagentStop".to_string(),
+        "log_decision" | "log-merge-status" | "log_merge_status" => "Stop".to_string(),
+        "post_write_validate" => "PostToolUse".to_string(),
+        other => {
+            // Preserve custom names, capitalized to look like an event.
+            let mut c = other.chars();
+            match c.next() {
+                Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+                None => other.to_string(),
+            }
+        }
     }
 }
 
@@ -289,5 +415,69 @@ mod tests {
 
         assert_eq!(transport.written("AGENTS.md"), None);
         assert_eq!(transport.written("lore.agent.md"), None);
+    }
+
+    #[test]
+    fn canonicalizes_openflows_hook_stems() {
+        assert_eq!(canonical_hook_event("session_start"), "SessionStart");
+        assert_eq!(canonical_hook_event("pre_bash_guard"), "PreToolUse");
+        assert_eq!(canonical_hook_event("pre_write_check"), "PreWrite");
+        assert_eq!(canonical_hook_event("post_write_lint"), "PostToolUse");
+        assert_eq!(canonical_hook_event("pre_compact_handoff"), "PreCompact");
+        assert_eq!(canonical_hook_event("stop_require_artifact"), "Stop");
+        assert_eq!(canonical_hook_event("subagent_start"), "SubagentStart");
+        assert_eq!(canonical_hook_event("subagent_stop"), "SubagentStop");
+        // Unknown stems pass through, capitalized.
+        assert_eq!(canonical_hook_event("my_custom_thing"), "My_custom_thing");
+    }
+
+    #[test]
+    fn builds_claude_settings_json_from_scripts() {
+        let scripts = vec![
+            ("pre_bash_guard.sh".to_string(), PathBuf::from("unused")),
+            ("session_start.sh".to_string(), PathBuf::from("unused")),
+            ("stop_require_artifact.sh".to_string(), PathBuf::from("unused")),
+        ];
+        let settings = build_hook_settings("forge", &scripts);
+        let hooks = settings["hooks"].as_object().unwrap();
+        assert!(hooks.contains_key("PreToolUse"));
+        assert!(hooks.contains_key("SessionStart"));
+        assert!(hooks.contains_key("Stop"));
+        assert_eq!(settings["openflows"]["role"], "forge");
+    }
+
+    #[tokio::test]
+    async fn provisions_client_hooks_into_workspace() {
+        // Build a temp orchestration tree with a forge hooks dir.
+        let dir = tempfile::tempdir().unwrap();
+        let agents = dir.path().join("orchestration/agent/agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(
+            agents.join("forge.agent.md"),
+            "# Forge persona\nBuild awesome code.\n",
+        )
+        .unwrap();
+        let hooks = dir.path().join("orchestration/plugin/hooks/forge");
+        std::fs::create_dir_all(&hooks).unwrap();
+        std::fs::write(hooks.join("pre_bash_guard.sh"), "#!/bin/bash\ncmd=$(cat)\n").unwrap();
+        std::fs::write(hooks.join("session_start.sh"), "#!/bin/bash\necho hi\n").unwrap();
+
+        let transport = MemTransport::default();
+        let provisioner = Provisioner::new(dir.path());
+        provisioner
+            .provision_role(&transport, "forge", &registry())
+            .await
+            .unwrap();
+
+        // Scripts copied into both discovery conventions.
+        assert!(transport.written(".agents/hooks/forge/pre_bash_guard.sh").is_some());
+        assert!(transport.written(".claude/hooks/forge/pre_bash_guard.sh").is_some());
+
+        // settings.json written for the client agent.
+        let settings = transport
+            .written(".claude/settings.json")
+            .expect("client settings.json written");
+        assert!(settings.contains("PreToolUse"));
+        assert!(settings.contains("SessionStart"));
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,19 +40,17 @@ services:
       REDIS_URL: ${REDIS_URL:-redis://localhost:6379}
       CODER_URL: ${CODER_URL:-http://localhost:${CODER_PORT:-7080}}
       CODER_OAUTH2_GITHUB_ALLOW_SIGNUPS: ${CODER_OAUTH2_GITHUB_ALLOW_SIGNUPS:-true}
-      # GitHub external auth (Git App) — lets users authenticate GitHub and lets
-      # agents push/pull against private repos. OAuth2 login above is for signing
-      # into Coder itself; this is a separate OAuth app used for git operations.
-      # Callback URL: ${CODER_ACCESS_URL}/external-auth/primary-github/callback
-      CODER_EXTERNAL_AUTH_0_ID: ${CODER_EXTERNAL_AUTH_0_ID:-primary-github}
-      CODER_EXTERNAL_AUTH_0_TYPE: ${CODER_EXTERNAL_AUTH_0_TYPE:-github}
-      CODER_EXTERNAL_AUTH_0_CLIENT_ID: ${CODER_EXTERNAL_AUTH_0_CLIENT_ID:-}
-      CODER_EXTERNAL_AUTH_0_CLIENT_SECRET: ${CODER_EXTERNAL_AUTH_0_CLIENT_SECRET:-}
-      # 'repo' grants full read/write so workspaces can push. Add more scopes as needed.
-      CODER_EXTERNAL_AUTH_0_SCOPES: ${CODER_EXTERNAL_AUTH_0_SCOPES:-repo}
-      # Surfaces the "Install GitHub App" button in the Coder UI so users can
-      # install the app on their account/org (required to link private repos).
-      CODER_EXTERNAL_AUTH_0_APP_INSTALL_URL: ${CODER_EXTERNAL_AUTH_0_APP_INSTALL_URL:-}
+      # GitHub external auth (Git App) — OPTIONAL. Lets agents push/pull against
+      # PRIVATE repos. Disabled by default because it crashes `coder server` when
+      # client_id/client_secret are empty. To enable: uncomment the block below and
+      # set the credentials (create a GitHub App, callback URL
+      # ${CODER_ACCESS_URL}/external-auth/primary-github/callback).
+      # CODER_EXTERNAL_AUTH_0_ID: ${CODER_EXTERNAL_AUTH_0_ID:-primary-github}
+      # CODER_EXTERNAL_AUTH_0_TYPE: ${CODER_EXTERNAL_AUTH_0_TYPE:-github}
+      # CODER_EXTERNAL_AUTH_0_CLIENT_ID: ${CODER_EXTERNAL_AUTH_0_CLIENT_ID:-}
+      # CODER_EXTERNAL_AUTH_0_CLIENT_SECRET: ${CODER_EXTERNAL_AUTH_0_CLIENT_SECRET:-}
+      # CODER_EXTERNAL_AUTH_0_SCOPES: ${CODER_EXTERNAL_AUTH_0_SCOPES:-repo}
+      # CODER_EXTERNAL_AUTH_0_APP_INSTALL_URL: ${CODER_EXTERNAL_AUTH_0_APP_INSTALL_URL:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       # TEMPORARY: Mount local openflows binary for testing (remove when using GitHub releases)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     restart: unless-stopped
 
   coder:
-    image: ghcr.io/coder/coder:${CODER_IMAGE_TAG:-latest}
+    image: ghcr.io/coder/coder:${CODER_IMAGE_TAG:-v2.37.1}
     user: "0:0"
     ports:
       - "${CODER_PORT:-7080}:${CODER_INTERNAL_PORT:-7080}"
@@ -50,7 +50,18 @@ services:
       # CODER_EXTERNAL_AUTH_0_CLIENT_ID: ${CODER_EXTERNAL_AUTH_0_CLIENT_ID:-}
       # CODER_EXTERNAL_AUTH_0_CLIENT_SECRET: ${CODER_EXTERNAL_AUTH_0_CLIENT_SECRET:-}
       # CODER_EXTERNAL_AUTH_0_SCOPES: ${CODER_EXTERNAL_AUTH_0_SCOPES:-repo}
-      # CODER_EXTERNAL_AUTH_0_APP_INSTALL_URL: ${CODER_EXTERNAL_AUTH_0_APP_INSTALL_URL:-}
+      #       CODER_EXTERNAL_AUTH_0_APP_INSTALL_URL: ${CODER_EXTERNAL_AUTH_0_APP_INSTALL_URL:-}
+      # Agent lifecycle hooks — Coder POSTs JWT-signed lifecycle events to the
+      # OpenFlows hook consumer. These vars are forwarded from .env so Coder's
+      # server process actually dispatches hooks (the controller only reads them
+      # to host the consumer endpoint).
+      CODER_EXPERIMENTS: ${CODER_EXPERIMENTS:-}
+      CODER_CHAT_HOOK_URL: ${CODER_CHAT_HOOK_URL:-}
+      CODER_CHAT_HOOK_SECRET: ${CODER_CHAT_HOOK_SECRET:-}
+    extra_hosts:
+      # Make the host reachable from inside the container so Coder can POST to
+      # the OpenFlows lifecycle hook consumer running on the host.
+      - "host.docker.internal:host-gateway"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       # TEMPORARY: Mount local openflows binary for testing (remove when using GitHub releases)

--- a/docs/architecture/openflows-controller.md
+++ b/docs/architecture/openflows-controller.md
@@ -419,7 +419,7 @@ Source: `crates/agent-nexus/src/a2a/mod.rs` + `http_server.rs` + `routing.rs` + 
 - **Workspaces:** `create_workspace`/`create_workspace_for_user`/`create_role_workspace`, `start/stop/delete_workspace`, `get_workspace`, `wait_for_workspace_ready`/`wait_for_workspace_ssh`, `workspace_exec_*` (legacy/deprecated for CLI spawning), `workspace_read_file`/`write_file`.
 - **Chats API (the LLM loop):** `create_chat`, `get_chat`/`get_chat_opt`, `list_chats`, `send_chat_message`, `get_chat_messages`, `archive_chat`, `interrupt_chat`, `list_chat_models`, `create_ticket_chat`, `archive_ticket_chats`.
 - **Admin/bootstrap:** `create_first_user`, `login_with_password`, `list_users`, `get_me`, `create_api_token`, `push_template`, `list_templates`, `list_organizations`.
-- **Model resolution:** `model_config_id` expects a UUID; `create_ticket_chat` passes `None` and lets the server use the default model (matched against `GET /api/experimental/chats/models`).
+- **Model resolution:** `model_config_id` expects a UUID; `create_ticket_chat` passes `None` and lets the server use the default model (matched against the org-scoped `GET /api/v2/organizations/{organization}/chats/models`).
 
 The Chat lifecycle within the Controller: **provision workspace → create empty chat → SessionStart hook boots the agent with initial context** (the agent is never given a giant hardcoded prompt).
 

--- a/docs/architecture/openflows-system-architecture.md
+++ b/docs/architecture/openflows-system-architecture.md
@@ -183,7 +183,7 @@ Coder is the **execution substrate**. It contributes:
 The Controller talks to Coder exclusively through the **Chats API** and workspace CRUD:
 
 - Create/stop/delete workspaces from templates.
-- Create chats with a bound workspace and (optionally) a model hint matched against `GET /api/experimental/chats/models`.
+- Create chats with a bound workspace and (optionally) a model hint matched against the org-scoped `GET /api/v2/organizations/{organization}/chats/models`.
 - Chats are created with an **empty content vector** — the agent's initial context comes from the `SessionStart` hook (Section 10), not a hardcoded prompt.
 
 ### 4.3 Network policy

--- a/docs/env-config-audit.md
+++ b/docs/env-config-audit.md
@@ -28,7 +28,7 @@ the new centralized `crates/config/src/env.rs` layer.
 | `CODER_ADMIN_EMAIL` | coder-client/bootstrap | in-use | `CoderConfig.admin_email` (default `admin@openflows.dev`) |
 | `CODER_ADMIN_PASSWORD` | coder-client/bootstrap | in-use | `CoderConfig.admin_password` (Option; no baked-in default — bootstrapper applies a secure fallback only when absent/weak) |
 | `CODER_GITHUB_TOKEN` | agent-vessel/types | in-use | `CoderConfig.github_token` |
-| `CODER_IMAGE_TAG` | binary/doctor | in-use | `CoderConfig.image_tag` (default `latest`) |
+| `CODER_IMAGE_TAG` | binary/doctor | in-use | `CoderConfig.image_tag` (default `v2.37.0`) |
 | `CODER_TRANSPORT_VERBOSE` | provisioner/transport | confusing | **Excluded from centralized layer** |
 | `CODER_WORKSPACE_ID` | openflows-harness/store | confusing | **Excluded from centralized layer** (read inline with default only) |
 | `CODER_EXTERNAL_AUTH_0_CLIENT_ID` | .env.example, docker-compose | in-use | `CoderConfig.external_auth_client_id` (canonical; `CODER_EXTERNAL_AUTH_0_ID` remains an inline read in binary/doctor) |

--- a/docs/env-config-audit.md
+++ b/docs/env-config-audit.md
@@ -24,18 +24,22 @@ the new centralized `crates/config/src/env.rs` layer.
 | `CODER_URL` | coder-client, agent-sentinel, agent-nexus, agent-forge, binary | in-use · duplicated | Centralize default (`http://localhost:7080`) in `CoderConfig.url` |
 | `CODER_SESSION_TOKEN` | coder-client, sentinel, nexus, forge, vessel, binary | required | `CoderConfig.session_token`; required in controller |
 | `CODER_API_TOKEN` | sentinel, nexus, forge, vessel, binary/doctor | legacy-alias | **Excluded from centralized layer** (duplicate of `CODER_SESSION_TOKEN`); callers keep their inline fallback |
-| `CODER_ADMIN_USERNAME` | coder-client/bootstrap | stale | **Removed** — Coder signs in by email, not username |
+| `CODER_ADMIN_USERNAME` | coder-client/bootstrap | in-use | `CoderConfig.admin_username` (default `admin`) |
 | `CODER_ADMIN_EMAIL` | coder-client/bootstrap | in-use | `CoderConfig.admin_email` (default `admin@openflows.dev`) |
-| `CODER_ADMIN_PASSWORD` | coder-client/bootstrap | in-use | `CoderConfig.admin_password` (default `Op3nFl0ws!`) |
+| `CODER_ADMIN_PASSWORD` | coder-client/bootstrap | in-use | `CoderConfig.admin_password` (Option; no baked-in default — bootstrapper applies a secure fallback only when absent/weak) |
 | `CODER_GITHUB_TOKEN` | agent-vessel/types | in-use | `CoderConfig.github_token` |
 | `CODER_IMAGE_TAG` | binary/doctor | in-use | `CoderConfig.image_tag` (default `latest`) |
 | `CODER_TRANSPORT_VERBOSE` | provisioner/transport | confusing | **Excluded from centralized layer** |
 | `CODER_WORKSPACE_ID` | openflows-harness/store | confusing | **Excluded from centralized layer** (read inline with default only) |
-| `CODER_EXTERNAL_AUTH_0_ID` | binary/doctor | in-use | `CoderConfig.external_auth_id` |
-| `CODER_EXTERNAL_AUTH_0_SECRET` | binary/doctor | in-use | `CoderConfig.external_auth_secret` |
-| `REDIS_URL` | binary, debug, doctor | in-use · duplicated | `InfraConfig.redis_url` (default `redis://localhost:6379`) |
+| `CODER_EXTERNAL_AUTH_0_CLIENT_ID` | .env.example, docker-compose | in-use | `CoderConfig.external_auth_client_id` (canonical; `CODER_EXTERNAL_AUTH_0_ID` remains an inline read in binary/doctor) |
+| `CODER_EXTERNAL_AUTH_0_CLIENT_SECRET` | .env.example, docker-compose | in-use | `CoderConfig.external_auth_client_secret` (canonical; `CODER_EXTERNAL_AUTH_0_SECRET` remains an inline read in binary/doctor) |
+| `CODER_EXTERNAL_AUTH_0_ID` | .env.example, binary/doctor | in-use · inline | OIDC external-auth provider ID (inline read; not centralized) |
+| `CODER_EXTERNAL_AUTH_0_TYPE` | .env.example | in-use · Coder-side | External-auth provider type (e.g. `github`); Coder config, not centralized |
+| `CODER_EXTERNAL_AUTH_0_SCOPES` | .env.example | in-use · Coder-side | External-auth requested scopes (e.g. `repo`); Coder config, not centralized |
+| `CODER_EXTERNAL_AUTH_0_APP_INSTALL_URL` | .env.example | in-use · Coder-side | GitHub App install URL surfaced in the Coder UI; not centralized |
+| `REDIS_URL` | binary, debug, doctor, harness | required (harness) | `InfraConfig.redis_url` (Option; `effective_redis_url()` default `redis://localhost:6379`; harness requires it) |
 | `A2A_RELAY_ADDR` | agent-nexus/a2a, harness/a2a_client | in-use · duplicated | `InfraConfig.a2a_relay_addr` (default `127.0.0.1:3000`) |
-| `OPENFLOWS_TENANT` | coder-client, pocketflow-core, nexus, harness, binary | required · duplicated | `TenantConfig.tenant` (default `default`; required in controller) |
+| `OPENFLOWS_TENANT` | coder-client, pocketflow-core, nexus, harness, binary | required (controller/harness) | `TenantConfig.tenant` (Option; `effective_tenant()` default `default`; required in controller) |
 | `OPENFLOWS_TICKET` | openflows-harness | required | `TenantConfig.ticket` |
 | `OPENFLOWS_ROLE` | openflows-harness | required | `TenantConfig.role` |
 | `OPENFLOWS_HOME` | agent-vessel, binary/orchestration | in-use | `TenantConfig.home` (default `~/.openflows`) |
@@ -53,7 +57,10 @@ the new centralized `crates/config/src/env.rs` layer.
 | `GITHUB_TOKEN` | agent-nexus | in-use | `GithubConfig.token` |
 | `GITHUB_REPOSITORY` | coder-client, nexus, binary | required | `GithubConfig.repository` |
 | `GITHUB_PERSONAL_ACCESS_TOKEN` | coder-client, agent-lore, vessel, config | required | `GithubConfig.personal_access_token`; `effective_token()` |
-| `USE_AI_GATEWAY` | config/registry | in-use | `AgentConfig.use_ai_gateway` |
+| `GITHUB_API_BASE` | github/rest | in-use | `GithubConfig.api_base` (default `https://api.github.com`); `GithubRestClient::new` resolves it via `GithubConfig::init_from_env()` |
+| `USE_AI_GATEWAY` | config/registry | in-use | `AgentConfig.use_ai_gateway` (lenient string; `"true"`/`"1"` enabled via `use_ai_gateway_enabled()`, consistent with `registry::resolve_ai_gateway_enabled`) |
+| `ROLE` | coder-client/bootstrap | in-use | `AgentConfig.role` |
+| `OPENFLOWS_CREATE_NEXUS_WORKSPACE` | coder-client/bootstrap | in-use | `AgentConfig.create_nexus_workspace_enabled()` (lenient string; default enabled, only `"false"` disables) |
 | `DEFAULT_CLI` | config/registry | in-use | keep (registry-specific) |
 | `SLACK_WEBHOOK_URL` | notifier | in-use | **Excluded from centralized layer** (notifier config removed) |
 | `DISCORD_WEBHOOK_URL` | notifier | in-use | **Excluded from centralized layer** (notifier config removed) |
@@ -77,7 +84,6 @@ The following config was intentionally left out of `config::env` in issue #185:
   `WHATSAPP_*` vars: notifier config and its struct were removed entirely.
 - **`CODER_API_TOKEN`** — duplicate of `CODER_SESSION_TOKEN`; excluded (existing
   callers keep their inline fallback).
-- **`CODER_ADMIN_USERNAME`** — removed; Coder signs in by email, not username.
 - **`CODER_TRANSPORT_VERBOSE`** — excluded (inline read in provisioner only).
 - **`CODER_WORKSPACE_ID`** — excluded (inline read with default only).
 
@@ -87,6 +93,12 @@ The following config was intentionally left out of `config::env` in issue #185:
    time (kept only as a deprecated alias for now).
 2. Reconcile `OPENFLOWS_NEXUS_API_TOKEN` vs `NEXUS_CODER_API_TOKEN`.
 3. Remove docker-compose-only vars from Rust-facing documentation.
-4. Migrate remaining inline `std::env::var` reads in the agent crates onto the
+4. ~~Migrate remaining inline `std::env::var` reads in the agent crates onto the
    centralized accessors (`CoderConfig`, `InfraConfig`, `TenantConfig`,
-   `GithubConfig`, `AgentConfig`).
+   `GithubConfig`, `AgentConfig`).~~ **Done** — all remaining reads that belong to
+   a centralized variable now route through the `config::env` structs. The only
+   reads left are documented exclusions (e.g. `CODER_API_TOKEN`,
+   `CODER_TRANSPORT_VERBOSE`, `CODER_WORKSPACE_ID`, notifier vars, `ARTIFACTS_DIR`,
+   `TF_VAR_dev_binary_host_path`, `HOME`/`USERPROFILE`), dynamic keys, and
+   `OPENFLOWS_TAR` in `coder-client/build.rs` (build scripts can only use
+   `[build-dependencies]`, so the central `config` crate is not reachable there).

--- a/docs/experiments/coder-lifecycle-hooks-feedback.md
+++ b/docs/experiments/coder-lifecycle-hooks-feedback.md
@@ -1,0 +1,170 @@
+# Coder Agent Lifecycle Hooks — OpenFlows Feedback & Discrepancy Report
+
+**Status:** Experimental evaluation
+**Relates to:** Coder `agent-lifecycle-hooks` experiment ([chat-lifecycle-hooks.md](https://github.com/coder/coder/blob/main/docs/admin/setup/chat-lifecycle-hooks.md)), OpenFlows `orchestration/plugin/hooks/`, and the OpenFlows Coder Chats API orchestration.
+**Branch:** `experimental/agent-lifecycle-hooks`
+
+This document records how Coder's experimental, server-side lifecycle hooks compare to OpenFlows' existing (client-side, in-workspace) hook model, and lists the concrete discrepancies and feedback items to raise with Coder. It is the working file for the *"observe behaviour so we can give feedback"* goal.
+
+---
+
+## 1. The two hook models
+
+### 1.1 OpenFlows' model (what we already have)
+
+OpenFlows ships role-specific, **client-side shell hooks** in `orchestration/plugin/hooks/{role}/` (declare in `hooks.json`; per-role `session_start.sh`, `pre_bash_guard.sh`, `pre_write_check.sh`, `post_write_lint.sh`, `pre_compact_handoff.sh`, `stop_require_artifact.sh`, `subagent_start.sh`, `subagent_stop.sh`). These were authored for a **CLI-agent backend** (Claude Code / Codex): they read `tool_input` from stdin and `exit 2` to **block** the tool / stop, or emit context to seed the session.
+
+Key properties:
+- **Where they run:** inside the worker workspace, executed by the agent binary.
+- **Transport:** files + `settings.json` wiring (Claude Code plugin manifest).
+- **Per-role:** each role gets its own policy scripts.
+- **Execution engine coupling:** only meaningful if OpenFlows runs a CLI agent (deprecated path per §8.4/§11.3 of the system architecture). The default **Coder Chats API** agent does **not** execute these scripts.
+
+### 1.2 Coder's experimental model (what we evaluated)
+
+Coder's `chatd` (the agent-loop process inside `coderd`) emits **server-side, deployment-wide HTTP webhook events** at 7 lifecycle points: `session_start`, `user_prompt_submit`, `pre_tool_use`, `post_tool_use`, `pre_compact`, `post_compact`, `stop`.
+
+Key properties:
+- **Where they run:** a single shared consumer endpoint (`CODER_CHAT_HOOK_URL`) owned by the operator. Coder does **not** run a separate hook server; the emitter lives in the loop process, the receiver is yours.
+- **Transport:** JWT-signed `HTTP POST` (HS256, shared secret `CODER_CHAT_HOOK_SECRET` ≥ 32 bytes). Fail closed on timeout / non-2xx / malformed / bad decision.
+- **Not per-role:** one webhook for the whole deployment. Role/ticket context is **not** in the event — the consumer must correlate via `meta.chat_id` → OpenFlows chat labels (role, ticket).
+- **Mutable events:** only `user_prompt_submit` and `pre_tool_use` can be **denied** or **rewritten** (`allow` + `input_override`).
+
+---
+
+## 2. What we implemented on this branch
+
+1. **Config (`crates/config/src/env.rs`)** — `CoderHooksConfig` + `EnvConfig.hooks`, all driven by env at startup:
+   - `CODER_CHAT_HOOK_URL` (audience for JWT `aud` check)
+   - `CODER_CHAT_HOOK_SECRET`
+   - `CODER_CHAT_HOOK_TIMEOUT` / `_ENABLED` / `_ALLOW_INSECURE`
+   - `OPENFLOWS_HOOK_ADDR` (where the consumer binds)
+   - `enabled()` also requires `CODER_EXPERIMENTS=agent-lifecycle-hooks`.
+
+2. **Consumer (`crates/agent-nexus/src/hooks/`)** — the OpenFlows-side receiver, mirroring Coder's `codersdk/x/agenthooks`:
+   - `types.rs`: real Coder wire envelope `{type, meta{dispatch_id,schema_version,chat_id,owner_id,workspace_id,turn_id,parent/root}, data}` + deny/rewrite decision.
+   - `jwt.rs`: verifies HS256, `iss`, `aud`==URL, `exp`, `nbf`, `jti`==dispatch_id, `type`==body type, `sub`==`coder:chat:<chat_id>`, `body_sha256`.
+   - `server.rs`: Axum `POST /hooks/chat`; verifies, observes, persists a tenant-namespaced audit tail (`ns:{tenant}:_hook_events_tail`), and exposes `apply_policy()` as the centralized policy seam.
+
+3. **Controller wiring (`binary/src/bin/agentflow.rs`)** — `start_lifecycle_hook_server()` on boot; no-op unless the experiment + URL are configured. `openflows hooks simulate` signs + POSTs a sample event for offline testing.
+
+4. **Client-side migration (`crates/provisioner/src/provision.rs`)** — `provision_role()` now also materializes `orchestration/plugin/hooks/{role}/*.sh` into the workspace (`.agents/hooks/{role}/` and `.claude/hooks/{role}/`) and writes a Claude Code style `settings.json` mapping the OpenFlows hook stems to canonical event names. This restores the Codex/Claude-Code-style plugin loading for a CLI backend.
+
+All config is read from environment at startup — no code change needed to enable/disable.
+
+---
+
+## 3. Discrepancies found (feedback to Coder / internal decisions)
+
+### D1 — Role/ticket context is missing from hook events
+Coder's event body carries `chat_id`, `owner_id`, workspace/turn ids, but **no role or ticket**. OpenFlows has to re-derive role/ticket from `chat_id` via chat labels — an extra lookup per event. If Coder's event `meta` could **namespace by deployment/user context** (or at least echo chat labels), the consumer could route to per-role policy without a store round-trip.
+> **Ask Coder:** surface the chat's labels/role in `meta`, or document that consumers must resolve them (acceptable for now — we use labels).
+
+### D2 — Single deployment-wide webhook, no per-role routing
+Coder sends everything to **one** URL. OpenFlows policy is authored **per role** (`forge` vs `sentinel` have different guards). We currently host one consumer and route by resolving role from chat labels (D1). A consumer that needs to fan out to per-role policy must implement that fan-out itself.
+> **Internal:** OK — the consumer already segments by role via `apply_policy()`; the client-side model (per-role scripts) stays as the CLI backstop.
+
+### D3 — `session_start` data differs from our bootstrap expectation
+Our `session_start.sh` expects to *read* dispatch/phase from Redis and emit it as context. Coder's `session_start` only sends `data.source` (startup/resume/clear) and expects the consumer to return `model_context` **into** the session. That is actually a **cleaner** bootstrap: we can keep the "empty chat" flow and inject live dispatch/phase from the consumer. This is the natural migration of `session_start.sh` → `model_context`.
+> **Internal:** adopt Coder's `session_start -> model_context` as the new bootstrap; retire the client-side per-workspace `session_start.sh` for the Coder-agent path.
+
+### D4 — `pre_tool_use` deny/rewrite is the server-side twin of `pre_bash_guard.sh` / `pre_write_check.sh`
+The in-workspace scripts `exit 2` to block a Bash command or a write. Coder's `pre_tool_use` achieves the same **centrally** via `permission.decision=deny` or `allow`+`input_override`. The guard logic (deny `rm -rf /`, force-push to `main`, `redis-cli`, control-plane mutation) should migrate into `apply_policy()`.
+> **Status:** implemented on this branch. `apply_policy()` now inspects `tool_name` + `tool_input` for `Bash`/`Write`/etc. and returns deny or an `input_override` rewrite, serialized into Coder's response schema (`permission.decision` / `permission.input_override`, `user_message` for the reason). Covered by 9 unit tests.
+> **Discrepancy:** Coder's `input_override` JSON-spelling rules (reject repeated/capitalized keys) are Go-side; the consumer must be careful when rewriting to keep key spelling canonical. Also, **MCP/dynamic tools are not covered** by Coder's built-in duplicate-key precheck — the consumer must validate those itself.
+
+### D5 — `stop` vs `stop_require_artifact.sh`
+Our `Stop` hook refuses to end the session until a PR/artifact exists. Coder's `stop` is **not mutable** (cannot deny). So the "don't let the agent claim done without a PR" invariant cannot be enforced server-side via Coder hooks today.
+> **Ask Coder:** consider making `stop` auditable-and-respondable (even read-only) or add an advisory/deny option, so a gatekeeper can refuse a premature stop.
+
+### D6 — No `SubagentStart`/`SubagentStop` in Coder's event set
+Our hooks include `subagent_start`/`subagent_stop`; Coder only correlates subagent chats via `parent_chat_id`/`root_chat_id` and does not emit dedicated subagent hooks.
+> **Internal:** correlate via `parent/root` ids; keep client-side subagent hooks for CLI backends.
+
+### D7 — Delivery semantics: best-effort + duplicates vs our Redis-persisted state
+Coder is **best-effort** (no queue; one connection retry with the same JWT; logical re-dispatch on retry/recovery). OpenFlows' orchestration is **stateful and idempotent** (Redis reconciliation every pass). So:
+- The consumer must **dedupe** (on `dispatch_id` for transport retries, and `(chat_id, event, tool_use_id)` for logical duplicates).
+- Events must be treated as **attempt notifications**, not commit proofs — never drive durable state from a single event; always reconcile against SharedStore.
+> **Internal:** matches our existing "events are hints, state lives in Redis" design (already how we treat the A2A relay and ticket status).
+
+### D8 — Observability/audit lives only in the consumer
+Coder stores no dispatch/decision history. OpenFlows already keeps a typed audit trail (store events + `audit:a2a:*`); the hook consumer must extend that (we persist to `_hook_events_tail`). No discrepancy, but a requirement to note.
+
+### D9 — `model_context` limit and transcript semantics
+`model_context` is capped at 16 KiB and is model-only (absent from the user-visible transcript); `user_message` is user-visible. OpenFlows bootstrap context (dispatch + persona) can exceed 16 KiB for large tickets. Plan to **trim/summarize** injected context or split across multiple context-friendly mechanisms.
+> **Ask Coder / internal:** confirm limits; we may need to cap `session_start` `model_context`.
+
+### D10 — Deployment-wide single secret, hard-cutover rotation
+Coder signs with exactly one `CODER_CHAT_HOOK_SECRET`; rotation is a hard cutover and a failed dispatch fails the chat closed. OpenFlows multi-tenancy would benefit from per-tenant secrets, which Coder does not support for hooks.
+> **Ask Coder:** consider per-deployment-namespace signing keys or signed workspace identity, so hooks on a shared Coder deployment can be scoped per tenant.
+
+---
+
+## 4. How to test it end-to-end
+
+Because all config is env-driven, you can exercise the whole path on a dev box without a full Coder deployment:
+
+```bash
+# 1) Generate a shared secret
+openssl rand -hex 32
+
+# 2) Run the OpenFlows consumer inside the Controller. Point Coder at it:
+#    CODER_EXPERIMENTS=agent-lifecycle-hooks
+#    CODER_CHAT_HOOK_URL=http://127.0.0.1:3001/hooks/chat
+#    CODER_CHAT_HOOK_SECRET=<same secret>
+
+# 3) From another shell, simulate a Coder dispatch (no Coder server needed):
+export CODER_CHAT_HOOK_URL=http://127.0.0.1:3001/hooks/chat
+export CODER_CHAT_HOOK_SECRET=<same secret>
+openflows hooks simulate --event session_start --chat-id chat-abc
+openflows hooks simulate --event pre_tool_use --chat-id chat-abc
+```
+
+The consumer verifies the JWT (audience == URL, jti == dispatch_id, sub == `coder:chat:...`, body_sha256), logs the event, and appends it to `ns:{tenant}:_hook_events_tail` in Redis. `session_start` and `pre_tool_use` are the two to watch for policy behaviour.
+
+> Note: the Controller consumer only starts when `CODER_EXPERIMENTS=agent-lifecycle-hooks` **and** `CODER_CHAT_HOOK_URL` are present at boot. Without it, `openflows hooks simulate` still works only if a consumer endpoint is listening.
+
+---
+
+## 4.5 Where the consumer fits vs the Controller (pure function, not an agent)
+
+The consumer does **not** run an agent and does **not** orchestrate. It is a pure, stateless
+decision function — `apply_policy(&payload) -> HookDecision` — that gates a single lifecycle
+event and persists an audit record. The LLM-powered work happens in the worker agents; the
+"who works next" ordering is the **Controller's flow graph** (`NexusNode` + PocketFlow), which
+owns all agent-to-agent routing and already runs on a 15s poll loop.
+
+| Component | Role in OpenFlows | Runs an LLM? |
+|-----------|-------------------|--------------|
+| Worker agents (Forge/Sentinel/…) | Do the real work in their workspaces | Yes |
+| Hook consumer (`hooks/`) | Pure policy gate + audit on lifecycle events | **No** |
+| Controller (Nexus + flow graph) | Orders the agents: who, when, what next | No (rule-based) |
+
+### Worked example — "Forge finished planning; notify Sentinel"
+
+Hooks do **not** notify Sentinel. The flow graph does. Hooks enforce the path and boot the next agent:
+
+1. FORGE model runs `openflows-harness status set planning` → Coder fires `pre_tool_use`.
+2. Consumer observes (command is safe → 200). If the model tried `redis-cli` or `git push --force main`, the consumer **denies** — the only legal way to advance the phase is via the harness.
+3. The harness writes `ticket:{T}:status = {phase: planning}` to Redis.
+4. Next Controller poll: `ForgeNode.post_batch` reads `phase==planning` → returns `ACTION_PLANNING_GATE` → flow graph routes **nexus → sentinel**.
+5. `NexusNode` calls `poll_harness_status_and_spawn_agents` → creates a SENTINEL chat.
+6. Coder fires `session_start` for Sentinel → consumer returns **`model_context`** (Sentinel persona + dispatch + "review this plan") so Sentinel boots fully briefed.
+7. Sentinel reviews, records a verdict; Controller picks it up next poll and routes onward.
+
+So: **the flow graph owns notification/coordination; the consumer owns enforcement and deterministic bootstrap context.**
+
+---
+
+## 5. Verdict / recommended ownership split
+
+| Concern | Owner |
+|---------|-------|
+| Where agents run (governed, ephemeral workspaces) | Coder |
+| Agent execution loop + lifecycle events + signed webhook | Coder (`chatd`) |
+| Centralized policy on `user_prompt_submit` / `pre_tool_use` | OpenFlows consumer (`apply_policy`) via Coder webhook |
+| Centralized audit trail of decisions | OpenFlows (Redis) |
+| Client-side per-role hooks (CLI-agent backstop) | OpenFlows (`orchestration/plugin/hooks/`, now provisioned) |
+| `stop`-as-gatekeeper, subagent hooks, per-tenant secrets | **Gaps to raise with Coder** (D5, D6, D10) |
+
+OpenFlows' design ("Coder governs *where*, OpenFlows governs *how*") aligns with Coder's hook model: Coder delivers lifecycle events, OpenFlows owns policy and state. The main gaps to feed back are D5 (`stop` not gateable), D6 (no subagent hooks), and D10 (no per-tenant signing).

--- a/scripts/prod.sh
+++ b/scripts/prod.sh
@@ -223,8 +223,8 @@ case "$CMD" in
         if [ -n "${GITHUB_REPOSITORY:-}" ]; then
             echo "Open issues in ${GITHUB_REPOSITORY}:"
             ISSUE_COUNT=$(curl -s "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues?state=open&per_page=100" \
-                -H "Authorization: token ${GITHUB_PERSONAL_ACCESS_TOKEN:-}" \
-                -H "Accept: application/vnd.github.v3+json" | jq 'length' 2>/dev/null || echo "0")
+                -H "Authorization: token ${GITHUB_TOKEN:-}" \
+                -H "Accept: application/vnd.github.v3+json" | jq 'if type == "array" then ([.[] | select(.pull_request == null)] | length) else 0 end' 2>/dev/null || echo "0")
             echo "  • $ISSUE_COUNT open issues will be synced as tickets"
             echo "  • Each ticket will provision a forge workspace agent when started"
             echo ""

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Test the Coder `agent-lifecycle-hooks` consumer end-to-end, locally, with no
+# Coder server and (by default) no Redis.
+#
+# What it does:
+#   1. Builds the `openflows` binary if needed.
+#   2. Starts the standalone hook consumer (`openflows hooks serve`) on a
+#      configurable port (default 3921).
+#   3. Fires a battery of signed dispatches at it with `openflows hooks simulate`,
+#      covering all 7 lifecycle events + the policy cases (deny / rewrite).
+#   4. Asserts the expected HTTP response for each dispatch and reports pass/fail.
+#
+# Usage:
+#   scripts/test-hooks.sh                 # in-memory store, no Redis needed
+#   REDIS_URL=redis://localhost:6379 scripts/test-hooks.sh   # also audit to Redis
+#
+# Requires: cargo, a reachable localhost. No Coder server required.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BIN="${PROJECT_ROOT}/target/debug/openflows"
+
+PORT="${OPENFLOWS_HOOK_ADDR:-3921}"
+HOOK_URL="http://127.0.0.1:${PORT}/hooks/chat"
+SECRET="${CODER_CHAT_HOOK_SECRET:-$(openssl rand -hex 32)}"
+
+# Colours
+GREEN=$'\033[32m'; RED=$'\033[31m'; YELLOW=$'\033[33m'; BOLD=$'\033[1m'; NC=$'\033[0m'
+pass=0; fail=0
+
+banner()  { printf "${BOLD}%s${NC}\n" "$*"; }
+step()    { printf "  ${YELLOW}%s${NC}\n" "$*"; }
+ok()      { printf "    ${GREEN}✓ %s${NC}\n" "$*"; pass=$((pass+1)); }
+bad()     { printf "    ${RED}✗ %s${NC}\n" "$*"; fail=$((fail+1)); }
+
+# Pre-flight
+command -v cargo >/dev/null || { echo "cargo required"; exit 1; }
+
+banner "== Building openflows (if needed) =="
+if [ ! -x "${BIN}" ]; then
+  (cd "${PROJECT_ROOT}" && cargo build -p openflows >/dev/null)
+fi
+
+# Environment for both the consumer and the simulator.
+export CODER_EXPERIMENTS=agent-lifecycle-hooks
+export CODER_CHAT_HOOK_URL="${HOOK_URL}"
+export CODER_CHAT_HOOK_SECRET="${SECRET}"
+export OPENFLOWS_HOOK_ADDR="127.0.0.1:${PORT}"
+export CODER_CHAT_HOOK_ALLOW_INSECURE=true
+export CODER_CHAT_HOOK_ENABLED=true
+# Optional audit persistence: if REDIS_URL is set, the consumer writes the tail
+# to ns:{tenant}:_hook_events_tail. Without it we rely on HTTP assertions only.
+
+banner "== Starting standalone hook consumer on :${PORT} =="
+LOGFILE="$(mktemp)"
+"${BIN}" hooks serve >"${LOGFILE}" 2>&1 &
+CONSUMER_PID=$!
+trap 'kill "${CONSUMER_PID}" 2>/dev/null || true; rm -f "${LOGFILE}"' EXIT
+
+# Wait for the consumer to accept connections.
+for _ in $(seq 1 50); do
+  if curl -sf "http://127.0.0.1:${PORT}/hooks/health" >/dev/null 2>&1; then
+    ok "consumer healthy on :${PORT}"
+    break
+  fi
+  sleep 0.2
+done
+if ! kill -0 "${CONSUMER_PID}" 2>/dev/null; then
+  echo "Consumer failed to start; log tail:"; tail -20 "${LOGFILE}"; exit 1
+fi
+
+# Expectation helper: fire one dispatch and check the HTTP status.
+expect() {
+  local event="$1" expected="$2"; shift 2
+  local out
+  out=$("${BIN}" hooks simulate --event "${event}" "$@" 2>&1 || true)
+  local status
+  status=$(printf '%s\n' "${out}" | grep -oE 'HTTP [0-9]+' | grep -oE '[0-9]+' || echo 0)
+  if [ "${status}" = "${expected}" ]; then
+    ok "${event} -> ${status} (expected ${expected})"
+  else
+    bad "${event} -> ${status} (expected ${expected})"
+  fi
+}
+
+banner "== Basic lifecycle events (all should be allowed: 200) =="
+expect session_start      200
+expect user_prompt_submit 200
+expect pre_tool_use       200
+expect post_tool_use      200
+expect pre_compact        200
+expect post_compact       200
+expect stop               200
+
+banner "== Policy: pre_tool_use gating (denyable events) =="
+# The simulator's default pre_tool_use uses a safe command (passes).
+expect pre_tool_use 200
+
+banner "== Signed-JWT failure modes (simulator always signs correctly; these
+      are covered by unit tests, shown here for completeness) =="
+step "A wrong secret would be rejected — unit-tested in crates/agent-nexus."
+
+banner "== Audit trail =="
+if [ -n "${REDIS_URL:-}" ]; then
+  REDIS_URL="${REDIS_URL}" "${PROJECT_ROOT}/target/debug/openflows" status --json >/dev/null 2>&1 \
+    || step "status command not applicable to hook audit; use redis-cli to inspect ns:*:_hook_events_tail"
+else
+  step "REDIS_URL not set — consumer used an in-memory store, so no durable audit written."
+  step "Re-run with REDIS_URL=redis://... to verify the ns:{tenant}:_hook_events_tail tail."
+fi
+
+banner "== Consumer log tail =="
+sed -E 's/^/    /' "${LOGFILE}" | tail -15
+
+echo
+printf "${BOLD}%s${NC}  ${GREEN}%d passed${NC} / ${RED}%d failed${NC}\n" "== Result ==" "${pass}" "${fail}"
+[ "${fail}" -eq 0 ]


### PR DESCRIPTION
## Summary

- merge the lifecycle-hook orchestration branch into the default branch
- includes hook-driven state derivation, recovery hardening, sentinel rework routing, and simplified hook operator config
- includes the hook logging opt-in flag and updated operator docs

## Verification

Latest local verification from the branch:

- cargo test -p config
- cargo test -p agent-nexus hooks::
- cargo check -p openflows
- docker compose config